### PR TITLE
TD-8270 Implement parallel bulk uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- [TD-7788] `TdCore.Search.BulkUploader` for parallel Elasticsearch bulk
+- [TD-8270] `TdCore.Search.BulkUploader` for parallel Elasticsearch bulk
   uploads during hot-swap and partial reindex.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- [TD-7788] `TdCore.Search.BulkUploader` for parallel Elasticsearch bulk
+  uploads during hot-swap and partial reindex.
+
+### Changed
+
+- `TdCore.Search.Indexer` uses parallel bulk posts via `ES_REINDEX_CONCURRENCY`.
+- `TdCore.Search.IndexWorkerImpl` skips duplicate full `:all` reindex casts
+  while one is already running.
+
 ## [8.8.1] 2026-06-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - [TD-8270] `TdCore.Search.BulkUploader` for parallel Elasticsearch bulk
   uploads during hot-swap and partial reindex.
+- [TD-8270] `:skip_forcemerge` cluster option (also accepted as an
+  `Indexer.refresh/3` opt), letting each service decide whether the post
+  hot-swap forcemerge runs. Defaults to `false`, preserving previous behaviour.
+- [TD-8270] `:refresh_recv_timeout` cluster option (also accepted as an
+  `Indexer.refresh/3` opt) capping the `_refresh` request at 5s so it does not
+  inherit `ES_RECV_TIMEOUT`. `_forcemerge` keeps the cluster default.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@
 ### Changed
 
 - `TdCore.Search.Indexer` uses parallel bulk posts via `ES_REINDEX_CONCURRENCY`.
-- `TdCore.Search.IndexWorkerImpl` skips duplicate full `:all` reindex casts
-  while one is already running.
 
 ## [8.8.3] 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [8.9.0] 2026-07-29
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - [TD-8270] `:refresh_recv_timeout` cluster option (also accepted as an
   `Indexer.refresh/3` opt) capping the `_refresh` request at 5s so it does not
   inherit `ES_RECV_TIMEOUT`. `_forcemerge` keeps the cluster default.
+- [TD-8270] `:reindex_concurrency` accepted per index in the `indexes` config,
+  overriding the cluster-wide value for that index.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,17 @@ end
 
 ## Environment variables
 
-# If the variable is set to false, it will not be deleted in the case that there is no index in the hot swap process.
--  ON_ERROR_DELETE_INDEX: detault true
+Most Elasticsearch cluster options (`reindex_concurrency`, `recv_timeout`,
+`delete_existing_index`, forcemerge, aliases, etc.) are **not** read from the
+environment by td-core. The host application (e.g. `td-dd`) maps env vars in
+`config/runtime.exs` into `config :td_core, TdCore.Search.Cluster`. See that
+service's README for the full list (`ES_REINDEX_CONCURRENCY`, `ES_RECV_TIMEOUT`,
+`DELETE_EXISTING_INDEX`, …).
 
+Variables read directly by td-core at runtime:
+
+- `ES_BULK_TOOK_LOG`: when set to `1`, `true`, or `yes` (case-insensitive), logs
+  Elasticsearch `took` per successful bulk page. Default: off.
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ environment by td-core. The host application (e.g. `td-dd`) maps env vars in
 service's README for the full list (`ES_REINDEX_CONCURRENCY`, `ES_RECV_TIMEOUT`,
 `DELETE_EXISTING_INDEX`, …).
 
-Variables read directly by td-core at runtime:
-
-- `ES_BULK_TOOK_LOG`: when set to `1`, `true`, or `yes` (case-insensitive), logs
-  Elasticsearch `took` per successful bulk page. Default: off.
+Per-page bulk indexing counts and Elasticsearch `took` are logged at `debug`
+level, so they follow the service's configured `Logger` level rather than a
+dedicated variable.
 
 ### Post hot-swap forcemerge
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,33 @@ Variables read directly by td-core at runtime:
 - `ES_BULK_TOOK_LOG`: when set to `1`, `true`, or `yes` (case-insensitive), logs
   Elasticsearch `took` per successful bulk page. Default: off.
 
+### Post hot-swap forcemerge
+
+After a hot swap, td-core refreshes the new index and then forcemerges it using
+`:forcemerge_options`. Whether the forcemerge runs is an infrastructure
+decision, configured per service:
+
+```elixir
+config :td_core, TdCore.Search.Cluster,
+  skip_forcemerge: System.get_env("ES_SKIP_FORCEMERGE", "false") |> String.to_atom(),
+  forcemerge_options: [
+    wait_for_completion: System.get_env("ES_WAIT_FOR_COMPLETION", "nil") |> String.to_atom(),
+    max_num_segments: System.get_env("ES_MAX_NUM_SEGMENTS", "5") |> String.to_integer()
+  ]
+```
+
+`skip_forcemerge` defaults to `false`, so the forcemerge runs with the
+configured `wait_for_completion` and `max_num_segments` unless a service opts
+out. It can also be passed per call as `Indexer.refresh(cluster, name,
+skip_forcemerge: true)`.
+
+The `_refresh` request is capped by `:refresh_recv_timeout` (default `5_000` ms)
+so it does not inherit `ES_RECV_TIMEOUT`, which was adding roughly two minutes of
+hot-swap wall time after the last bulk page. Set it to `nil` to fall back to the
+cluster default. The `_forcemerge` request is not capped: it legitimately runs
+for minutes, and services that want it to return immediately should set
+`wait_for_completion: false` in `:forcemerge_options`.
+
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at <https://hexdocs.pm/td_core>.

--- a/lib/td_core/search/bulk_uploader.ex
+++ b/lib/td_core/search/bulk_uploader.ex
@@ -7,6 +7,7 @@ defmodule TdCore.Search.BulkUploader do
 
   alias Elasticsearch.Cluster.Config
   alias Elasticsearch.Index.Bulk
+  alias TdCore.Search.Indexer
 
   @doc """
   Uploads all data from the configured store to `index_name`, posting bulk
@@ -31,7 +32,9 @@ defmodule TdCore.Search.BulkUploader do
       |> Stream.intersperse(bulk_wait_interval)
       |> Stream.map(&put_bulk_page(config, index_name, &1))
       |> post_bulk_responses(concurrency)
-      |> Enum.reduce(errors, &collect_errors(&1, &2, action))
+      |> Enum.reduce(errors, fn response, acc ->
+        record_bulk_response(index_name, response, acc, action)
+      end)
 
     upload(config, index_name, %{index_config | sources: tail}, errors)
   end
@@ -78,6 +81,22 @@ defmodule TdCore.Search.BulkUploader do
   defp put_bulk_page(config, index_name, items) when is_list(items) do
     Elasticsearch.put(config, "/#{index_name}/_bulk", Enum.join(items))
   end
+
+  @doc false
+  def record_bulk_response(index_name, response, errors, action) do
+    maybe_log_bulk_post(index_name, response, action)
+    collect_errors(response, errors, action)
+  end
+
+  defp maybe_log_bulk_post(index_name, {:ok, _} = response, action) do
+    Indexer.log_bulk_post(index_name, response, action)
+  end
+
+  defp maybe_log_bulk_post(index_name, {:error, _} = response, action) do
+    Indexer.log_bulk_post(index_name, response, action)
+  end
+
+  defp maybe_log_bulk_post(_index_name, _response, _action), do: :ok
 
   defp collect_errors({:ok, %{"errors" => true} = response}, errors, action) do
     new_errors =

--- a/lib/td_core/search/bulk_uploader.ex
+++ b/lib/td_core/search/bulk_uploader.ex
@@ -1,0 +1,103 @@
+defmodule TdCore.Search.BulkUploader do
+  @moduledoc """
+  Parallel bulk upload helpers for Elasticsearch indexing.
+  """
+
+  require Logger
+
+  alias Elasticsearch.Cluster.Config
+  alias Elasticsearch.Index.Bulk
+
+  @doc """
+  Uploads all data from the configured store to `index_name`, posting bulk
+  pages in parallel when `reindex_concurrency` is greater than 1.
+  """
+  @spec upload(Config.t(), String.t(), map(), list()) :: :ok | {:error, list()}
+  def upload(_cluster, _index_name, %{sources: []}, []), do: :ok
+  def upload(_cluster, _index_name, %{sources: []}, errors), do: {:error, errors}
+
+  def upload(cluster, index_name, %{store: store, sources: [source | tail]} = index_config, errors) do
+    config = Config.get(cluster)
+    bulk_page_size = index_config[:bulk_page_size] || 5000
+    bulk_wait_interval = index_config[:bulk_wait_interval] || 0
+    action = index_config[:bulk_action] || "create"
+    concurrency = reindex_concurrency()
+
+    errors =
+      source
+      |> store.stream()
+      |> Stream.map(&Bulk.encode!(config, &1, index_name, action))
+      |> Stream.chunk_every(bulk_page_size)
+      |> Stream.intersperse(bulk_wait_interval)
+      |> Stream.map(&put_bulk_page(config, index_name, &1))
+      |> post_bulk_responses(concurrency)
+      |> Enum.reduce(errors, &collect_errors(&1, &2, action))
+
+    upload(config, index_name, %{index_config | sources: tail}, errors)
+  end
+
+  @doc """
+  Posts pre-built bulk request bodies to Elasticsearch.
+  """
+  @spec post_bulk_bodies(Enumerable.t(), atom(), String.t(), pos_integer()) :: Enumerable.t()
+  def post_bulk_bodies(bodies, cluster, path, concurrency) when concurrency <= 1 do
+    Stream.map(bodies, &Elasticsearch.post(cluster, path, &1))
+  end
+
+  def post_bulk_bodies(bodies, cluster, path, concurrency) do
+    bodies
+    |> Task.async_stream(
+      &Elasticsearch.post(cluster, path, &1),
+      max_concurrency: concurrency,
+      ordered: true,
+      timeout: :infinity
+    )
+    |> Stream.map(fn
+      {:ok, response} -> response
+      {:exit, reason} -> {:error, reason}
+    end)
+  end
+
+  defp post_bulk_responses(pages, concurrency) when concurrency <= 1, do: pages
+
+  defp post_bulk_responses(pages, concurrency) do
+    pages
+    |> Task.async_stream(& &1, max_concurrency: concurrency, ordered: true, timeout: :infinity)
+    |> Stream.map(fn
+      {:ok, response} -> response
+      {:exit, reason} -> {:error, reason}
+    end)
+  end
+
+  defp put_bulk_page(_config, _index_name, wait_interval) when is_integer(wait_interval) do
+    Logger.debug("Pausing #{wait_interval}ms between bulk pages")
+    :timer.sleep(wait_interval)
+    :ok
+  end
+
+  defp put_bulk_page(config, index_name, items) when is_list(items) do
+    Elasticsearch.put(config, "/#{index_name}/_bulk", Enum.join(items))
+  end
+
+  defp collect_errors({:ok, %{"errors" => true} = response}, errors, action) do
+    new_errors =
+      response["items"]
+      |> Enum.filter(&(&1[action]["error"] != nil))
+      |> Enum.map(& &1[action])
+      |> Enum.map(&Elasticsearch.Exception.exception(response: &1))
+
+    new_errors ++ errors
+  end
+
+  defp collect_errors({:error, error}, errors, _action), do: [error | errors]
+  defp collect_errors(_response, errors, _action), do: errors
+
+  defp reindex_concurrency do
+    cluster_config()
+    |> Keyword.get(:reindex_concurrency, System.schedulers_online())
+  end
+
+  defp cluster_config do
+    Application.get_env(:td_core, TdCore.Search.Cluster, [])
+  end
+end

--- a/lib/td_core/search/bulk_uploader.ex
+++ b/lib/td_core/search/bulk_uploader.ex
@@ -8,10 +8,15 @@ defmodule TdCore.Search.BulkUploader do
   alias Elasticsearch.Cluster.Config
   alias Elasticsearch.Index.Bulk
   alias TdCore.Search.Indexer
+  alias TdCore.Search.PhaseProfiler
 
   @doc """
   Uploads all data from the configured store to `index_name`, posting bulk
   pages in parallel when `reindex_concurrency` is greater than 1.
+
+  Consumes `store.stream/1` inside `store.transaction/1`, matching
+  `Elasticsearch.Index.Bulk.upload/4`, so stores that use `Repo.stream/1`
+  (e.g. implementations) stay inside a DB transaction.
   """
   @spec upload(Config.t(), String.t(), map(), list()) :: :ok | {:error, list()}
   def upload(_cluster, _index_name, %{sources: []}, []), do: :ok
@@ -25,14 +30,16 @@ defmodule TdCore.Search.BulkUploader do
     concurrency = reindex_concurrency()
 
     errors =
-      source
-      |> store.stream()
-      |> Stream.map(&Bulk.encode!(config, &1, index_name, action))
-      |> Stream.chunk_every(bulk_page_size)
-      |> Stream.intersperse(bulk_wait_interval)
-      |> post_bulk_pages(config, index_name, concurrency)
-      |> Enum.reduce(errors, fn response, acc ->
-        record_bulk_response(index_name, response, acc, action)
+      store.transaction(fn ->
+        source
+        |> store.stream()
+        |> Stream.map(&Bulk.encode!(config, &1, index_name, action))
+        |> Stream.chunk_every(bulk_page_size)
+        |> Stream.intersperse(bulk_wait_interval)
+        |> post_bulk_pages(config, index_name, concurrency)
+        |> Enum.reduce(errors, fn response, acc ->
+          record_bulk_response(index_name, response, acc, action)
+        end)
       end)
 
     upload(config, index_name, %{index_config | sources: tail}, errors)
@@ -43,13 +50,13 @@ defmodule TdCore.Search.BulkUploader do
   """
   @spec post_bulk_bodies(Enumerable.t(), atom(), String.t(), pos_integer()) :: Enumerable.t()
   def post_bulk_bodies(bodies, cluster, path, concurrency) when concurrency <= 1 do
-    Stream.map(bodies, &Elasticsearch.post(cluster, path, &1))
+    Stream.map(bodies, &post_bulk_body(cluster, path, &1))
   end
 
   def post_bulk_bodies(bodies, cluster, path, concurrency) do
     bodies
     |> Task.async_stream(
-      &Elasticsearch.post(cluster, path, &1),
+      &post_bulk_body(cluster, path, &1),
       max_concurrency: concurrency,
       ordered: true,
       timeout: :infinity
@@ -58,6 +65,10 @@ defmodule TdCore.Search.BulkUploader do
       {:ok, response} -> response
       {:exit, reason} -> {:error, reason}
     end)
+  end
+
+  defp post_bulk_body(cluster, path, body) do
+    PhaseProfiler.phase_time(:bulk_es, fn -> Elasticsearch.post(cluster, path, body) end)
   end
 
   defp post_bulk_pages(pages, config, index_name, concurrency) when concurrency <= 1 do
@@ -85,7 +96,9 @@ defmodule TdCore.Search.BulkUploader do
   end
 
   defp put_bulk_page(config, index_name, items) when is_list(items) do
-    Elasticsearch.put(config, "/#{index_name}/_bulk", Enum.join(items))
+    PhaseProfiler.phase_time(:bulk_es, fn ->
+      Elasticsearch.put(config, "/#{index_name}/_bulk", Enum.join(items))
+    end)
   end
 
   @doc false

--- a/lib/td_core/search/bulk_uploader.ex
+++ b/lib/td_core/search/bulk_uploader.ex
@@ -30,8 +30,7 @@ defmodule TdCore.Search.BulkUploader do
       |> Stream.map(&Bulk.encode!(config, &1, index_name, action))
       |> Stream.chunk_every(bulk_page_size)
       |> Stream.intersperse(bulk_wait_interval)
-      |> Stream.map(&put_bulk_page(config, index_name, &1))
-      |> post_bulk_responses(concurrency)
+      |> post_bulk_pages(config, index_name, concurrency)
       |> Enum.reduce(errors, fn response, acc ->
         record_bulk_response(index_name, response, acc, action)
       end)
@@ -61,11 +60,18 @@ defmodule TdCore.Search.BulkUploader do
     end)
   end
 
-  defp post_bulk_responses(pages, concurrency) when concurrency <= 1, do: pages
+  defp post_bulk_pages(pages, config, index_name, concurrency) when concurrency <= 1 do
+    Stream.map(pages, &put_bulk_page(config, index_name, &1))
+  end
 
-  defp post_bulk_responses(pages, concurrency) do
+  defp post_bulk_pages(pages, config, index_name, concurrency) do
     pages
-    |> Task.async_stream(& &1, max_concurrency: concurrency, ordered: true, timeout: :infinity)
+    |> Task.async_stream(
+      &put_bulk_page(config, index_name, &1),
+      max_concurrency: concurrency,
+      ordered: true,
+      timeout: :infinity
+    )
     |> Stream.map(fn
       {:ok, response} -> response
       {:exit, reason} -> {:error, reason}

--- a/lib/td_core/search/bulk_uploader.ex
+++ b/lib/td_core/search/bulk_uploader.ex
@@ -32,7 +32,7 @@ defmodule TdCore.Search.BulkUploader do
     bulk_page_size = index_config[:bulk_page_size] || 5000
     bulk_wait_interval = index_config[:bulk_wait_interval] || 0
     action = index_config[:bulk_action] || "create"
-    concurrency = reindex_concurrency()
+    concurrency = index_config[:reindex_concurrency] || reindex_concurrency()
 
     errors =
       store.transaction(fn ->

--- a/lib/td_core/search/bulk_uploader.ex
+++ b/lib/td_core/search/bulk_uploader.ex
@@ -22,7 +22,12 @@ defmodule TdCore.Search.BulkUploader do
   def upload(_cluster, _index_name, %{sources: []}, []), do: :ok
   def upload(_cluster, _index_name, %{sources: []}, errors), do: {:error, errors}
 
-  def upload(cluster, index_name, %{store: store, sources: [source | tail]} = index_config, errors) do
+  def upload(
+        cluster,
+        index_name,
+        %{store: store, sources: [source | tail]} = index_config,
+        errors
+      ) do
     config = Config.get(cluster)
     bulk_page_size = index_config[:bulk_page_size] || 5000
     bulk_wait_interval = index_config[:bulk_wait_interval] || 0

--- a/lib/td_core/search/index_worker_impl.ex
+++ b/lib/td_core/search/index_worker_impl.ex
@@ -74,23 +74,37 @@ defmodule TdCore.Search.IndexWorkerImpl do
   @impl GenServer
   def init(index) do
     Logger.info("Running IndexWorker for index #{index}")
-    {:ok, index}
+    {:ok, %{index: index, reindexing_all: false}}
   end
 
   @impl GenServer
-  def handle_cast({:reindex, ids}, index) do
+  def handle_cast({:reindex, :all}, %{reindexing_all: true, index: index} = state) do
+    Logger.warning("Skipping duplicate full reindex for #{index}; one is already in progress")
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:reindex, ids}, %{index: index} = state) do
     Logger.info("Started indexing for #{index}")
+
+    reindexing_all? = ids == :all
+
+    state =
+      if reindexing_all?, do: %{state | reindexing_all: true}, else: state
 
     Timer.time(
       fn -> Indexer.reindex(index, ids) end,
       fn millis, _ -> Logger.info("#{index} indexed in #{millis}ms") end
     )
 
-    {:noreply, index}
+    state =
+      if reindexing_all?, do: %{state | reindexing_all: false}, else: state
+
+    {:noreply, state}
   end
 
   @impl GenServer
-  def handle_cast({:put_embeddings, ids}, index) do
+  def handle_cast({:put_embeddings, ids}, %{index: index} = state) do
     Logger.info("Started embeddings update for #{index}")
 
     Timer.time(
@@ -98,28 +112,28 @@ defmodule TdCore.Search.IndexWorkerImpl do
       fn millis, _ -> Logger.info("#{index} embeddings put in #{millis} ms") end
     )
 
-    {:noreply, index}
+    {:noreply, state}
   end
 
   @impl GenServer
-  def handle_cast({:refresh_links, ids}, index) do
+  def handle_cast({:refresh_links, ids}, %{index: index} = state) do
     :ok = Indexer.refresh_links(index, ids)
 
-    {:noreply, index}
+    {:noreply, state}
   end
 
   @impl GenServer
-  def handle_cast({:delete, ids_or_tuple}, index) do
+  def handle_cast({:delete, ids_or_tuple}, %{index: index} = state) do
     Timer.time(
       fn -> Indexer.delete(index, ids_or_tuple) end,
       fn millis, _ -> Logger.info("#{index} deleted in #{millis}ms") end
     )
 
-    {:noreply, index}
+    {:noreply, state}
   end
 
   @impl GenServer
-  def handle_call({:index_document, document}, _from, index) do
+  def handle_call({:index_document, document}, _from, %{index: index} = state) do
     Logger.info("Indexing document for #{index}")
 
     response =
@@ -128,11 +142,11 @@ defmodule TdCore.Search.IndexWorkerImpl do
         fn millis, _ -> Logger.info("#{index} document indexed in #{millis}ms") end
       )
 
-    {:reply, response, index}
+    {:reply, response, state}
   end
 
   @impl GenServer
-  def handle_call({:index_documents_batch, documents}, _from, index) do
+  def handle_call({:index_documents_batch, documents}, _from, %{index: index} = state) do
     Logger.info("Indexing #{length(documents)} documents for #{index}")
 
     response =
@@ -141,18 +155,18 @@ defmodule TdCore.Search.IndexWorkerImpl do
         fn millis, _ -> Logger.info("#{index} batch indexed in #{millis}ms") end
       )
 
-    {:reply, response, index}
+    {:reply, response, state}
   end
 
   @impl GenServer
-  def handle_call({:delete_index_documents_by_query, query}, _from, index) do
+  def handle_call({:delete_index_documents_by_query, query}, _from, %{index: index} = state) do
     response =
       Timer.time(
         fn -> Indexer.delete_index_documents_by_query(index, query) end,
         fn millis, _ -> Logger.info("#{index} documents deleted in #{millis}ms") end
       )
 
-    {:reply, response, index}
+    {:reply, response, state}
   end
 
   defp get_indexes(module) do

--- a/lib/td_core/search/index_worker_impl.ex
+++ b/lib/td_core/search/index_worker_impl.ex
@@ -74,37 +74,23 @@ defmodule TdCore.Search.IndexWorkerImpl do
   @impl GenServer
   def init(index) do
     Logger.info("Running IndexWorker for index #{index}")
-    {:ok, %{index: index, reindexing_all: false}}
+    {:ok, index}
   end
 
   @impl GenServer
-  def handle_cast({:reindex, :all}, %{reindexing_all: true, index: index} = state) do
-    Logger.warning("Skipping duplicate full reindex for #{index}; one is already in progress")
-    {:noreply, state}
-  end
-
-  @impl GenServer
-  def handle_cast({:reindex, ids}, %{index: index} = state) do
+  def handle_cast({:reindex, ids}, index) do
     Logger.info("Started indexing for #{index}")
-
-    reindexing_all? = ids == :all
-
-    state =
-      if reindexing_all?, do: %{state | reindexing_all: true}, else: state
 
     Timer.time(
       fn -> Indexer.reindex(index, ids) end,
       fn millis, _ -> Logger.info("#{index} indexed in #{millis}ms") end
     )
 
-    state =
-      if reindexing_all?, do: %{state | reindexing_all: false}, else: state
-
-    {:noreply, state}
+    {:noreply, index}
   end
 
   @impl GenServer
-  def handle_cast({:put_embeddings, ids}, %{index: index} = state) do
+  def handle_cast({:put_embeddings, ids}, index) do
     Logger.info("Started embeddings update for #{index}")
 
     Timer.time(
@@ -112,28 +98,28 @@ defmodule TdCore.Search.IndexWorkerImpl do
       fn millis, _ -> Logger.info("#{index} embeddings put in #{millis} ms") end
     )
 
-    {:noreply, state}
+    {:noreply, index}
   end
 
   @impl GenServer
-  def handle_cast({:refresh_links, ids}, %{index: index} = state) do
+  def handle_cast({:refresh_links, ids}, index) do
     :ok = Indexer.refresh_links(index, ids)
 
-    {:noreply, state}
+    {:noreply, index}
   end
 
   @impl GenServer
-  def handle_cast({:delete, ids_or_tuple}, %{index: index} = state) do
+  def handle_cast({:delete, ids_or_tuple}, index) do
     Timer.time(
       fn -> Indexer.delete(index, ids_or_tuple) end,
       fn millis, _ -> Logger.info("#{index} deleted in #{millis}ms") end
     )
 
-    {:noreply, state}
+    {:noreply, index}
   end
 
   @impl GenServer
-  def handle_call({:index_document, document}, _from, %{index: index} = state) do
+  def handle_call({:index_document, document}, _from, index) do
     Logger.info("Indexing document for #{index}")
 
     response =
@@ -142,11 +128,11 @@ defmodule TdCore.Search.IndexWorkerImpl do
         fn millis, _ -> Logger.info("#{index} document indexed in #{millis}ms") end
       )
 
-    {:reply, response, state}
+    {:reply, response, index}
   end
 
   @impl GenServer
-  def handle_call({:index_documents_batch, documents}, _from, %{index: index} = state) do
+  def handle_call({:index_documents_batch, documents}, _from, index) do
     Logger.info("Indexing #{length(documents)} documents for #{index}")
 
     response =
@@ -155,18 +141,18 @@ defmodule TdCore.Search.IndexWorkerImpl do
         fn millis, _ -> Logger.info("#{index} batch indexed in #{millis}ms") end
       )
 
-    {:reply, response, state}
+    {:reply, response, index}
   end
 
   @impl GenServer
-  def handle_call({:delete_index_documents_by_query, query}, _from, %{index: index} = state) do
+  def handle_call({:delete_index_documents_by_query, query}, _from, index) do
     response =
       Timer.time(
         fn -> Indexer.delete_index_documents_by_query(index, query) end,
         fn millis, _ -> Logger.info("#{index} documents deleted in #{millis}ms") end
       )
 
-    {:reply, response, state}
+    {:reply, response, index}
   end
 
   defp get_indexes(module) do

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -241,6 +241,9 @@ defmodule TdCore.Search.Indexer do
 
   @bulk_load_refresh_interval "-1"
   @bulk_load_replicas 0
+  # Post-bulk finalize must not inherit ES_RECV_TIMEOUT (~120s): that wait
+  # was adding ~2 min to hot_swap wall after the last bulk page.
+  @hot_swap_refresh_recv_timeout 5_000
 
   @doc false
   def bulk_load_index_settings(settings) when is_map(settings) do
@@ -289,7 +292,7 @@ defmodule TdCore.Search.Indexer do
          {:index_alias, :ok} <- {:index_alias, Index.alias(config, name, to_string(alias_name))},
          {:index_clean_starting, :ok} <-
            {:index_clean_starting, Index.clean_starting_with(config, to_string(alias_name), 2)},
-         {:index_refresh, :ok} <- {:index_refresh, refresh(config, name)} do
+         {:index_refresh, :ok} <- {:index_refresh, finalize_hot_swap_index(Cluster, name)} do
       Logger.info(
         "Hot swap successful, finished reindexing, pointing alias #{alias_name} -> #{name}"
       )
@@ -440,17 +443,44 @@ defmodule TdCore.Search.Indexer do
     "#{Enum.count(exceptions)} errors"
   end
 
+  @doc false
+  def finalize_hot_swap_index(cluster, name) do
+    refresh(cluster, name,
+      skip_forcemerge: true,
+      recv_timeout: @hot_swap_refresh_recv_timeout
+    )
+  end
+
   def refresh(cluster, name, opts \\ []) do
+    http_opts = refresh_http_opts(opts)
+    skip_forcemerge? = Keyword.get(opts, :skip_forcemerge, false)
+
+    with {:ok, _} <- Elasticsearch.post(cluster, "/#{name}/_refresh", %{}, http_opts),
+         :ok <- maybe_forcemerge(cluster, name, opts, http_opts, skip_forcemerge?),
+         do: :ok
+  end
+
+  defp maybe_forcemerge(_cluster, _name, _opts, _http_opts, true), do: :ok
+
+  defp maybe_forcemerge(cluster, name, opts, http_opts, false) do
     forcemerge_options = forcemerge_config(opts)
 
-    with {:ok, _} <- Elasticsearch.post(cluster, "/#{name}/_refresh", %{}),
-         {:ok, _} <-
-           Elasticsearch.post(
-             cluster,
-             "/#{name}/_forcemerge?" <> URI.encode_query(forcemerge_options),
-             %{}
-           ),
-         do: :ok
+    case Elasticsearch.post(
+           cluster,
+           "/#{name}/_forcemerge?" <> URI.encode_query(forcemerge_options),
+           %{},
+           http_opts
+         ) do
+      {:ok, _} -> :ok
+      error -> error
+    end
+  end
+
+  defp refresh_http_opts(opts) do
+    case Keyword.get(opts, :recv_timeout) do
+      nil -> []
+      timeout -> [recv_timeout: timeout]
+    end
   end
 
   defp message(%Elasticsearch.Exception{} = e) do

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -10,6 +10,7 @@ defmodule TdCore.Search.Indexer do
   alias Elasticsearch.Index.Bulk
   alias TdCluster.Cluster.TdDd.Tasks
   alias TdCluster.Cluster.TdLm
+  alias TdCore.Search.BulkUploader
   alias TdCore.Search.Cluster
   alias TdCore.Search.ElasticDocumentProtocol
 
@@ -33,20 +34,19 @@ defmodule TdCore.Search.Indexer do
   @action "index"
   def reindex(index, ids) when is_list(ids) do
     alias_name = Cluster.alias_name(index)
-
     store = store_from_alias(alias_name)
+    bulk_page_size = Cluster.setting(index, :bulk_page_size)
+    concurrency = reindex_concurrency()
 
-    store.transaction(fn ->
-      alias_name
-      |> schema_from_alias()
-      |> store.stream(ids)
-      |> Stream.map(&Bulk.encode!(Cluster, &1, alias_name, @action))
-      |> Stream.chunk_every(Cluster.setting(index, :bulk_page_size))
-      |> Stream.map(&Enum.join(&1, ""))
-      |> Stream.map(&Elasticsearch.post(Cluster, "/#{alias_name}/_bulk", &1))
-      |> Stream.map(&log_bulk_post(alias_name, &1, @action))
-      |> Stream.run()
-    end)
+    alias_name
+    |> schema_from_alias()
+    |> store.stream(ids)
+    |> Stream.map(&Bulk.encode!(Cluster, &1, alias_name, @action))
+    |> Stream.chunk_every(bulk_page_size)
+    |> Stream.map(&Enum.join(&1, ""))
+    |> BulkUploader.post_bulk_bodies(Cluster, "/#{alias_name}/_bulk", concurrency)
+    |> Stream.map(&log_bulk_post(alias_name, &1, @action))
+    |> Stream.run()
   end
 
   def reindex(index, id), do: reindex(index, [id])
@@ -127,20 +127,19 @@ defmodule TdCore.Search.Indexer do
   @update_action "update"
   def put_embeddings(index, ids) when is_list(ids) do
     alias_name = Cluster.alias_name(index)
-
     store = store_from_alias(alias_name)
+    bulk_page_size = Cluster.setting(index, :bulk_page_size)
+    concurrency = reindex_concurrency()
 
-    store.transaction(fn ->
-      alias_name
-      |> schema_from_alias()
-      |> store.stream({:embeddings, ids})
-      |> Stream.map(&Bulk.encode!(Cluster, &1, alias_name, @update_action))
-      |> Stream.chunk_every(Cluster.setting(index, :bulk_page_size))
-      |> Stream.map(&Enum.join(&1, ""))
-      |> Stream.map(&Elasticsearch.post(Cluster, "/#{alias_name}/_bulk", &1))
-      |> Stream.map(&log_bulk_post(alias_name, &1, @update_action))
-      |> Stream.run()
-    end)
+    alias_name
+    |> schema_from_alias()
+    |> store.stream({:embeddings, ids})
+    |> Stream.map(&Bulk.encode!(Cluster, &1, alias_name, @update_action))
+    |> Stream.chunk_every(bulk_page_size)
+    |> Stream.map(&Enum.join(&1, ""))
+    |> BulkUploader.post_bulk_bodies(Cluster, "/#{alias_name}/_bulk", concurrency)
+    |> Stream.map(&log_bulk_post(alias_name, &1, @update_action))
+    |> Stream.run()
   end
 
   defp store_from_alias(alias_name) do
@@ -252,7 +251,8 @@ defmodule TdCore.Search.Indexer do
 
     with {:index_from_settings, :ok} <-
            {:index_from_settings, Index.create_from_settings(config, name, %{settings: settings})},
-         {:bulk_upload, :ok} <- {:bulk_upload, Bulk.upload(config, name, index_config)},
+         {:bulk_upload, :ok} <-
+           {:bulk_upload, BulkUploader.upload(config, name, index_config, [])},
          {:index_alias, :ok} <- {:index_alias, Index.alias(config, name, to_string(alias_name))},
          {:index_clean_starting, :ok} <-
            {:index_clean_starting, Index.clean_starting_with(config, to_string(alias_name), 2)},
@@ -488,5 +488,10 @@ defmodule TdCore.Search.Indexer do
 
   defp cluster_config do
     Application.get_env(:td_core, TdCore.Search.Cluster)
+  end
+
+  defp reindex_concurrency do
+    cluster_config()
+    |> Keyword.get(:reindex_concurrency, System.schedulers_online())
   end
 end

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -38,15 +38,17 @@ defmodule TdCore.Search.Indexer do
     bulk_page_size = Cluster.setting(index, :bulk_page_size)
     concurrency = reindex_concurrency()
 
-    alias_name
-    |> schema_from_alias()
-    |> store.stream(ids)
-    |> Stream.map(&Bulk.encode!(Cluster, &1, alias_name, @action))
-    |> Stream.chunk_every(bulk_page_size)
-    |> Stream.map(&Enum.join(&1, ""))
-    |> BulkUploader.post_bulk_bodies(Cluster, "/#{alias_name}/_bulk", concurrency)
-    |> Stream.map(&log_bulk_post(alias_name, &1, @action))
-    |> Stream.run()
+    store.transaction(fn ->
+      alias_name
+      |> schema_from_alias()
+      |> store.stream(ids)
+      |> Stream.map(&Bulk.encode!(Cluster, &1, alias_name, @action))
+      |> Stream.chunk_every(bulk_page_size)
+      |> Stream.map(&Enum.join(&1, ""))
+      |> BulkUploader.post_bulk_bodies(Cluster, "/#{alias_name}/_bulk", concurrency)
+      |> Stream.map(&log_bulk_post(alias_name, &1, @action))
+      |> Stream.run()
+    end)
   end
 
   def reindex(index, id), do: reindex(index, [id])
@@ -131,15 +133,17 @@ defmodule TdCore.Search.Indexer do
     bulk_page_size = Cluster.setting(index, :bulk_page_size)
     concurrency = reindex_concurrency()
 
-    alias_name
-    |> schema_from_alias()
-    |> store.stream({:embeddings, ids})
-    |> Stream.map(&Bulk.encode!(Cluster, &1, alias_name, @update_action))
-    |> Stream.chunk_every(bulk_page_size)
-    |> Stream.map(&Enum.join(&1, ""))
-    |> BulkUploader.post_bulk_bodies(Cluster, "/#{alias_name}/_bulk", concurrency)
-    |> Stream.map(&log_bulk_post(alias_name, &1, @update_action))
-    |> Stream.run()
+    store.transaction(fn ->
+      alias_name
+      |> schema_from_alias()
+      |> store.stream({:embeddings, ids})
+      |> Stream.map(&Bulk.encode!(Cluster, &1, alias_name, @update_action))
+      |> Stream.chunk_every(bulk_page_size)
+      |> Stream.map(&Enum.join(&1, ""))
+      |> BulkUploader.post_bulk_bodies(Cluster, "/#{alias_name}/_bulk", concurrency)
+      |> Stream.map(&log_bulk_post(alias_name, &1, @update_action))
+      |> Stream.run()
+    end)
   end
 
   defp store_from_alias(alias_name) do

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -239,6 +239,35 @@ defmodule TdCore.Search.Indexer do
     put_template_error
   end
 
+  @bulk_load_refresh_interval "-1"
+  @bulk_load_replicas 0
+
+  @doc false
+  def bulk_load_index_settings(settings) when is_map(settings) do
+    settings
+    |> Map.put("refresh_interval", @bulk_load_refresh_interval)
+    |> Map.put("number_of_replicas", @bulk_load_replicas)
+    |> Map.drop([:refresh_interval, :number_of_replicas])
+  end
+
+  @doc false
+  def production_index_settings(settings) when is_map(settings) do
+    %{
+      "index" => %{
+        "refresh_interval" => index_setting(settings, "refresh_interval", "5s"),
+        "number_of_replicas" => index_setting(settings, "number_of_replicas", 1)
+      }
+    }
+  end
+
+  @doc false
+  def restore_index_settings(cluster, index_name, settings) when is_map(settings) do
+    case Elasticsearch.put(cluster, "/#{index_name}/_settings", production_index_settings(settings)) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
   # Modified from Elasticsearch.Index.hot_swap for better logging and
   # error handling
   defp hot_swap(alias_name) do
@@ -247,12 +276,16 @@ defmodule TdCore.Search.Indexer do
     name = Index.build_name(alias_name)
     config = Config.get(Cluster)
     index_config = config[:indexes][alias_name]
-    settings = Map.get(mappings, :settings, index_config.settings)
+    production_settings = Map.get(mappings, :settings, index_config.settings)
+    bulk_load_settings = bulk_load_index_settings(production_settings)
 
     with {:index_from_settings, :ok} <-
-           {:index_from_settings, Index.create_from_settings(config, name, %{settings: settings})},
+           {:index_from_settings,
+            Index.create_from_settings(config, name, %{settings: bulk_load_settings})},
          {:bulk_upload, :ok} <-
            {:bulk_upload, BulkUploader.upload(config, name, index_config, [])},
+         {:restore_settings, :ok} <-
+           {:restore_settings, restore_index_settings(Cluster, name, production_settings)},
          {:index_alias, :ok} <- {:index_alias, Index.alias(config, name, to_string(alias_name))},
          {:index_clean_starting, :ok} <-
            {:index_clean_starting, Index.clean_starting_with(config, to_string(alias_name), 2)},
@@ -488,6 +521,13 @@ defmodule TdCore.Search.Indexer do
 
   defp cluster_config do
     Application.get_env(:td_core, TdCore.Search.Cluster)
+  end
+
+  defp index_setting(settings, key, default) when is_binary(key) do
+    atom_key = String.to_existing_atom(key)
+    Map.get(settings, key) || Map.get(settings, atom_key) || default
+  rescue
+    ArgumentError -> Map.get(settings, key, default)
   end
 
   defp reindex_concurrency do

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -383,7 +383,9 @@ defmodule TdCore.Search.Indexer do
   end
 
   def log_bulk_post(index, {:ok, %{"errors" => false, "items" => items, "took" => took}}, _action) do
-    Logger.info("#{index}: bulk indexed #{Enum.count(items)} documents (took=#{took})")
+    if bulk_took_log_enabled?() do
+      Logger.info("#{index}: bulk indexed #{Enum.count(items)} documents (took=#{took})")
+    end
   end
 
   def log_bulk_post(index, {:ok, %{"errors" => true, "items" => items}}, action) do
@@ -563,5 +565,12 @@ defmodule TdCore.Search.Indexer do
   defp reindex_concurrency do
     cluster_config()
     |> Keyword.get(:reindex_concurrency, System.schedulers_online())
+  end
+
+  defp bulk_took_log_enabled? do
+    case System.get_env("ES_BULK_TOOK_LOG") do
+      nil -> false
+      value -> String.downcase(String.trim(value)) in ["1", "true", "yes"]
+    end
   end
 end

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -338,6 +338,10 @@ defmodule TdCore.Search.Indexer do
       {:error, %Elasticsearch.Exception{message: message}} = failed_update ->
         Logger.warning("Index #{name} template update failed: #{message}")
         failed_update
+
+      {:error, error} = failed_update ->
+        Logger.warning("Index #{name} template update failed: #{inspect(error)}")
+        failed_update
     end
   end
 

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -267,7 +267,11 @@ defmodule TdCore.Search.Indexer do
 
   @doc false
   def restore_index_settings(cluster, index_name, settings) when is_map(settings) do
-    case Elasticsearch.put(cluster, "/#{index_name}/_settings", production_index_settings(settings)) do
+    case Elasticsearch.put(
+           cluster,
+           "/#{index_name}/_settings",
+           production_index_settings(settings)
+         ) do
       {:ok, _} -> :ok
       {:error, _} = error -> error
     end

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -245,9 +245,7 @@ defmodule TdCore.Search.Indexer do
 
   @bulk_load_refresh_interval "-1"
   @bulk_load_replicas 0
-  # Post-bulk finalize must not inherit ES_RECV_TIMEOUT (~120s): that wait
-  # was adding ~2 min to hot_swap wall after the last bulk page.
-  @hot_swap_refresh_recv_timeout 5_000
+  @refresh_recv_timeout 5_000
 
   @doc false
   def bulk_load_index_settings(settings) when is_map(settings) do
@@ -296,7 +294,7 @@ defmodule TdCore.Search.Indexer do
          {:index_alias, :ok} <- {:index_alias, Index.alias(config, name, to_string(alias_name))},
          {:index_clean_starting, :ok} <-
            {:index_clean_starting, Index.clean_starting_with(config, to_string(alias_name), 2)},
-         {:index_refresh, :ok} <- {:index_refresh, finalize_hot_swap_index(Cluster, name)} do
+         {:index_refresh, :ok} <- {:index_refresh, refresh(config, name)} do
       Logger.info(
         "Hot swap successful, finished reindexing, pointing alias #{alias_name} -> #{name}"
       )
@@ -453,43 +451,25 @@ defmodule TdCore.Search.Indexer do
     "#{Enum.count(exceptions)} errors"
   end
 
-  @doc false
-  def finalize_hot_swap_index(cluster, name) do
-    refresh(cluster, name,
-      skip_forcemerge: true,
-      recv_timeout: @hot_swap_refresh_recv_timeout
-    )
-  end
-
   def refresh(cluster, name, opts \\ []) do
-    http_opts = refresh_http_opts(opts)
-    skip_forcemerge? = Keyword.get(opts, :skip_forcemerge, false)
-
-    with {:ok, _} <- Elasticsearch.post(cluster, "/#{name}/_refresh", %{}, http_opts),
-         :ok <- maybe_forcemerge(cluster, name, opts, http_opts, skip_forcemerge?),
+    with {:ok, _} <-
+           Elasticsearch.post(cluster, "/#{name}/_refresh", %{}, refresh_http_opts(opts)),
+         :ok <- maybe_forcemerge(cluster, name, opts, skip_forcemerge?(opts)),
          do: :ok
   end
 
-  defp maybe_forcemerge(_cluster, _name, _opts, _http_opts, true), do: :ok
+  defp maybe_forcemerge(_cluster, _name, _opts, true), do: :ok
 
-  defp maybe_forcemerge(cluster, name, opts, http_opts, false) do
+  defp maybe_forcemerge(cluster, name, opts, false) do
     forcemerge_options = forcemerge_config(opts)
 
     case Elasticsearch.post(
            cluster,
            "/#{name}/_forcemerge?" <> URI.encode_query(forcemerge_options),
-           %{},
-           http_opts
+           %{}
          ) do
       {:ok, _} -> :ok
       error -> error
-    end
-  end
-
-  defp refresh_http_opts(opts) do
-    case Keyword.get(opts, :recv_timeout) do
-      nil -> []
-      timeout -> [recv_timeout: timeout]
     end
   end
 
@@ -560,7 +540,23 @@ defmodule TdCore.Search.Indexer do
   end
 
   defp cluster_config do
-    Application.get_env(:td_core, TdCore.Search.Cluster)
+    Application.get_env(:td_core, TdCore.Search.Cluster, [])
+  end
+
+  defp skip_forcemerge?(opts) do
+    default_config = Keyword.get(cluster_config(), :skip_forcemerge, false)
+
+    Keyword.get(opts, :skip_forcemerge, default_config)
+  end
+
+  defp refresh_http_opts(opts) do
+    default_config =
+      Keyword.get(cluster_config(), :refresh_recv_timeout, @refresh_recv_timeout)
+
+    case Keyword.get(opts, :refresh_recv_timeout, default_config) do
+      nil -> []
+      timeout -> [recv_timeout: timeout]
+    end
   end
 
   defp index_setting(settings, key, default) when is_binary(key) do

--- a/lib/td_core/search/indexer.ex
+++ b/lib/td_core/search/indexer.ex
@@ -389,9 +389,7 @@ defmodule TdCore.Search.Indexer do
   end
 
   def log_bulk_post(index, {:ok, %{"errors" => false, "items" => items, "took" => took}}, _action) do
-    if bulk_took_log_enabled?() do
-      Logger.info("#{index}: bulk indexed #{Enum.count(items)} documents (took=#{took})")
-    end
+    Logger.debug("#{index}: bulk indexed #{Enum.count(items)} documents (took=#{took})")
   end
 
   def log_bulk_post(index, {:ok, %{"errors" => true, "items" => items}}, action) do
@@ -569,12 +567,5 @@ defmodule TdCore.Search.Indexer do
   defp reindex_concurrency do
     cluster_config()
     |> Keyword.get(:reindex_concurrency, System.schedulers_online())
-  end
-
-  defp bulk_took_log_enabled? do
-    case System.get_env("ES_BULK_TOOK_LOG") do
-      nil -> false
-      value -> String.downcase(String.trim(value)) in ["1", "true", "yes"]
-    end
   end
 end

--- a/lib/td_core/search/phase_profiler.ex
+++ b/lib/td_core/search/phase_profiler.ex
@@ -1,0 +1,20 @@
+defmodule TdCore.Search.PhaseProfiler do
+  @moduledoc """
+  Optional phase timing hook for the search reindex pipeline.
+
+  When `:td_core, :search_phase_profiler` is configured as `{module, function}`,
+  `phase_time/2` delegates the measurement to `module.function(phase, fun)` and
+  returns its result. When the env is unset (production default) it runs `fun`
+  directly, adding no overhead and keeping the pipeline behaviour identical.
+  """
+
+  @type phase :: atom()
+
+  @spec phase_time(phase(), (-> result)) :: result when result: term()
+  def phase_time(phase, fun) when is_function(fun, 0) do
+    case Application.get_env(:td_core, :search_phase_profiler) do
+      {mod, name} -> apply(mod, name, [phase, fun])
+      _ -> fun.()
+    end
+  end
+end

--- a/lib/td_core/search/reindex_benchmark.ex
+++ b/lib/td_core/search/reindex_benchmark.ex
@@ -1,0 +1,375 @@
+defmodule TdCore.Search.ReindexBenchmark do
+  @moduledoc """
+  Generic harness for benchmarking `TdCore.Search.Indexer.reindex/2`.
+
+  Services provide index atom, target (`:all` or ids), `doc_count`, and an
+  optional `env_banner_fn` for service-specific knobs. Measurement (VM,
+  scheduler, GC, optional profile sampler) and summary formatting live here.
+
+  ## Options
+
+  * `:doc_count` — document count used for throughput (required)
+  * `:repeat` — number of runs (default `1`)
+  * `:profile` — enable memory/run_queue sampling (default `false`)
+  * `:profile_interval_ms` — sampler interval (default `500`)
+  * `:env_banner_fn` — zero-arity callback returning a keyword list of
+    extra banner lines (`[{label, value}, ...]`)
+  * `:info_fn` — one-arity callback for output (default `IO.puts/1`)
+  * `:reindex_fn` — two-arity `(index, target) -> result` (default
+    `Indexer.reindex/2`, overridable in tests)
+  """
+
+  alias TdCore.Search.Cluster
+  alias TdCore.Search.Indexer
+
+  @memory_keys [:total, :processes, :system, :atom, :binary, :ets, :code]
+  @default_profile_interval_ms 500
+
+  @doc """
+  Runs one or more timed `reindex` calls and prints banner + metrics.
+  Returns the list of per-run metric maps.
+  """
+  def run(index, target, opts \\ []) when is_atom(index) do
+    ensure_runtime_tools!()
+
+    doc_count = Keyword.fetch!(opts, :doc_count)
+    repeat = Keyword.get(opts, :repeat, 1)
+    profile? = Keyword.get(opts, :profile, false)
+    profile_interval_ms = Keyword.get(opts, :profile_interval_ms, @default_profile_interval_ms)
+    info = Keyword.get(opts, :info_fn, &IO.puts/1)
+    env_banner_fn = Keyword.get(opts, :env_banner_fn)
+    reindex_fn = Keyword.get(opts, :reindex_fn, &Indexer.reindex/2)
+
+    log_environment(index, target, doc_count, repeat, profile?, env_banner_fn, info)
+
+    results =
+      Enum.map(1..repeat, fn run ->
+        info.("\n=== Run #{run}/#{repeat} ===")
+        benchmark_run(index, target, doc_count, profile?, profile_interval_ms, reindex_fn, info)
+      end)
+
+    if repeat > 1, do: log_repeat_summary(results, info)
+
+    results
+  end
+
+  defp ensure_runtime_tools! do
+    {:ok, _} = Application.ensure_all_started(:runtime_tools)
+  end
+
+  defp benchmark_run(index, target, doc_count, profile?, profile_interval_ms, reindex_fn, info) do
+    :erlang.system_flag(:scheduler_wall_time, true)
+
+    before = vm_snapshot()
+    scheduler_before = scheduler_wall_sample()
+    gc_before = :erlang.statistics(:garbage_collection)
+
+    sampler =
+      if profile? do
+        start_sampler(profile_interval_ms)
+      end
+
+    start_ms = System.monotonic_time(:millisecond)
+
+    {micros, result} =
+      :timer.tc(fn ->
+        reindex_fn.(index, target)
+      end)
+
+    elapsed_ms = System.monotonic_time(:millisecond) - start_ms
+
+    samples =
+      if sampler do
+        stop_sampler(sampler)
+      else
+        []
+      end
+
+    vm_after = vm_snapshot()
+    scheduler_after = scheduler_wall_sample()
+    gc_after = :erlang.statistics(:garbage_collection)
+
+    metrics = %{
+      micros: micros,
+      elapsed_ms: elapsed_ms,
+      doc_count: doc_count,
+      result: result,
+      before: before,
+      vm_after: vm_after,
+      memory_delta: memory_delta(before.memory, vm_after.memory),
+      scheduler: scheduler_utilization(scheduler_before, scheduler_after),
+      gc: gc_delta(gc_before, gc_after),
+      samples: samples
+    }
+
+    log_run_metrics(metrics, profile_interval_ms, info)
+    metrics
+  end
+
+  defp start_sampler(interval_ms) do
+    parent = self()
+
+    spawn(fn ->
+      sampler_loop(parent, interval_ms, [])
+    end)
+  end
+
+  defp sampler_loop(parent, interval_ms, acc) do
+    receive do
+      :stop ->
+        send(parent, {:samples, Enum.reverse(acc)})
+    after
+      interval_ms ->
+        sample = %{
+          at_ms: System.monotonic_time(:millisecond),
+          memory_total: :erlang.memory(:total),
+          run_queue: run_queue_lengths()
+        }
+
+        sampler_loop(parent, interval_ms, [sample | acc])
+    end
+  end
+
+  defp stop_sampler(pid) do
+    send(pid, :stop)
+
+    receive do
+      {:samples, samples} -> samples
+    after
+      5_000 -> []
+    end
+  end
+
+  defp vm_snapshot do
+    %{
+      memory: memory_map(),
+      process_count: :erlang.system_info(:process_count),
+      port_count: :erlang.system_info(:port_count),
+      atom_count: :erlang.system_info(:atom_count),
+      run_queue: run_queue_lengths()
+    }
+  end
+
+  defp memory_map do
+    Map.new(@memory_keys, fn key -> {key, :erlang.memory(key)} end)
+  end
+
+  defp memory_delta(before, vm_after) do
+    Map.new(@memory_keys, fn key ->
+      {key, Map.get(vm_after, key, 0) - Map.get(before, key, 0)}
+    end)
+  end
+
+  defp run_queue_lengths do
+    case :erlang.statistics(:run_queue) do
+      {total, cpu, io} -> %{total: total, cpu: cpu, io: io}
+      total when is_integer(total) -> %{total: total, cpu: total, io: 0}
+    end
+  end
+
+  defp scheduler_wall_sample do
+    :scheduler.get_sample()
+  end
+
+  defp scheduler_utilization(nil, _), do: empty_scheduler_metrics()
+  defp scheduler_utilization(_, nil), do: empty_scheduler_metrics()
+
+  defp scheduler_utilization(before, wall_after) do
+    case :scheduler.utilization(before, wall_after) do
+      results when is_list(results) ->
+        %{
+          percent: scheduler_util_value(results, :total),
+          weighted_percent: scheduler_util_value(results, :weighted)
+        }
+
+      _ ->
+        empty_scheduler_metrics()
+    end
+  end
+
+  defp empty_scheduler_metrics do
+    %{percent: nil, weighted_percent: nil}
+  end
+
+  defp scheduler_util_value(results, key) do
+    case Enum.find(results, fn {tag, _, _} -> tag == key end) do
+      {_, util, _} when is_float(util) -> Float.round(util * 100, 2)
+      _ -> nil
+    end
+  end
+
+  defp gc_delta(before, gc_after) do
+    {count_b, words_b} = gc_stats_pair(before)
+    {count_a, words_a} = gc_stats_pair(gc_after)
+
+    %{
+      collections: count_a - count_b,
+      words_reclaimed: words_a - words_b
+    }
+  end
+
+  defp gc_stats_pair({count, words}), do: {count, words}
+  defp gc_stats_pair({count, words, _}), do: {count, words}
+
+  defp log_run_metrics(%{micros: micros, doc_count: doc_count} = metrics, profile_interval_ms, info) do
+    throughput = throughput_per_sec(doc_count, micros)
+
+    info.("""
+    Timing:
+      wall_clock           #{format_micros(micros)} (#{micros} µs / #{div(micros, 1_000)} ms)
+      throughput           #{throughput} docs/s
+      reindex result       #{inspect(metrics.result)}
+
+    Memory (BEAM, before → after, Δ):
+      total                #{format_bytes(metrics.before.memory.total)} → #{format_bytes(metrics.vm_after.memory.total)} (#{format_delta(metrics.memory_delta.total)})
+      processes            #{format_bytes(metrics.before.memory.processes)} → #{format_bytes(metrics.vm_after.memory.processes)} (#{format_delta(metrics.memory_delta.processes)})
+      binary               #{format_bytes(metrics.before.memory.binary)} → #{format_bytes(metrics.vm_after.memory.binary)} (#{format_delta(metrics.memory_delta.binary)})
+      ets                  #{format_bytes(metrics.before.memory.ets)} → #{format_bytes(metrics.vm_after.memory.ets)} (#{format_delta(metrics.memory_delta.ets)})
+      system               #{format_bytes(metrics.before.memory.system)} → #{format_bytes(metrics.vm_after.memory.system)} (#{format_delta(metrics.memory_delta.system)})
+
+    CPU (BEAM schedulers):
+      utilization          #{format_percent(metrics.scheduler.percent)} (total, normal + dirty-cpu)
+      weighted utilization #{format_percent(metrics.scheduler.weighted_percent)} (vs available CPU time)
+
+    Scheduler run queues (after):
+      total                #{metrics.vm_after.run_queue.total}
+      cpu                  #{metrics.vm_after.run_queue.cpu}
+      io                   #{metrics.vm_after.run_queue.io}
+
+    GC:
+      collections          #{metrics.gc.collections}
+      words reclaimed      #{metrics.gc.words_reclaimed}
+
+    VM (after):
+      processes            #{metrics.vm_after.process_count}
+      ports                #{format_count(metrics.vm_after.port_count)}
+      atoms                #{format_count(metrics.vm_after.atom_count)}
+    """)
+
+    log_profile_samples(metrics.samples, profile_interval_ms, info)
+  end
+
+  defp log_profile_samples([], _profile_interval_ms, _info), do: :ok
+
+  defp log_profile_samples(samples, profile_interval_ms, info) do
+    memory_values = Enum.map(samples, & &1.memory_total)
+    rq_total = Enum.map(samples, & &1.run_queue.total)
+
+    info.("""
+    Profile samples (#{length(samples)} every #{profile_interval_ms} ms):
+      memory total         min #{format_bytes(Enum.min(memory_values))}  max #{format_bytes(Enum.max(memory_values))}  avg #{format_bytes(avg(memory_values))}
+      run_queue total      min #{Enum.min(rq_total)}  max #{Enum.max(rq_total)}  avg #{Float.round(avg(rq_total), 1)}
+    """)
+  end
+
+  defp log_repeat_summary(results, info) do
+    micros_list = Enum.map(results, & &1.micros)
+    percent_list = Enum.map(results, & &1.scheduler.percent) |> Enum.reject(&is_nil/1)
+
+    scheduler_summary =
+      if percent_list == [] do
+        "      scheduler util       n/a"
+      else
+        "      scheduler util       min #{format_percent(Enum.min(percent_list))}  max #{format_percent(Enum.max(percent_list))}  avg #{format_percent(Float.round(avg(percent_list), 2))}"
+      end
+
+    info.("""
+
+    === Repeat summary (#{length(results)} runs) ===
+      wall_clock           min #{format_micros(Enum.min(micros_list))}  max #{format_micros(Enum.max(micros_list))}  avg #{format_micros(trunc(avg(micros_list)))}
+    #{scheduler_summary}
+    """)
+  end
+
+  defp log_environment(index, target, doc_count, repeat, profile?, env_banner_fn, info) do
+    concurrency =
+      :td_core
+      |> Application.get_env(Cluster, [])
+      |> Keyword.get(:reindex_concurrency, System.schedulers_online())
+
+    bulk_page_size =
+      :td_core
+      |> Application.get_env(Cluster, [])
+      |> get_in([:indexes, index, :bulk_page_size])
+
+    target_label =
+      case target do
+        :all -> ":all"
+        list when is_list(list) -> "#{length(list)} ids"
+        other -> inspect(other)
+      end
+
+    baseline = vm_snapshot()
+
+    extra_lines =
+      case env_banner_fn do
+        fun when is_function(fun, 0) ->
+          fun.()
+          |> List.wrap()
+          |> Enum.map_join("\n", fn
+            {label, value} ->
+              label = to_string(label)
+              pad = String.duplicate(" ", max(1, 21 - String.length(label)))
+              "      #{label}#{pad}#{value}"
+
+            line when is_binary(line) ->
+              line
+          end)
+          |> case do
+            "" -> ""
+            lines -> "\n" <> lines
+          end
+
+        _ ->
+          ""
+      end
+
+    info.("""
+    Benchmark configuration:
+      target               #{target_label}
+      documents            #{doc_count}
+      runs                 #{repeat}
+      profile sampling     #{profile?}
+      reindex_concurrency  #{concurrency}
+      bulk_page_size       #{inspect(bulk_page_size)}#{extra_lines}
+      schedulers_online    #{System.schedulers_online()}
+      otp_release          #{System.otp_release()}
+      elixir               #{System.version()}
+      baseline memory      #{format_bytes(baseline.memory.total)} (processes=#{format_bytes(baseline.memory.processes)}, ets=#{format_bytes(baseline.memory.ets)})
+    """)
+  end
+
+  defp throughput_per_sec(_doc_count, micros) when micros <= 0, do: "n/a"
+
+  defp throughput_per_sec(doc_count, micros) do
+    secs = micros / 1_000_000
+    Float.round(doc_count / secs, 2)
+  end
+
+  defp format_micros(micros) when micros < 1_000_000 do
+    "#{Float.round(micros / 1_000, 2)} ms"
+  end
+
+  defp format_micros(micros) do
+    "#{Float.round(micros / 1_000_000, 2)} s"
+  end
+
+  defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
+  defp format_bytes(bytes) when bytes < 1024 * 1024, do: "#{Float.round(bytes / 1024, 1)} KiB"
+  defp format_bytes(bytes), do: "#{Float.round(bytes / (1024 * 1024), 2)} MiB"
+
+  defp format_delta(bytes) when bytes >= 0, do: "+#{format_bytes(bytes)}"
+  defp format_delta(bytes), do: format_bytes(bytes)
+
+  defp format_percent(nil), do: "n/a"
+  defp format_percent(percent), do: "#{percent}%"
+
+  defp format_count(value) when is_integer(value), do: Integer.to_string(value)
+  defp format_count(value), do: inspect(value)
+
+  defp avg([]), do: 0
+
+  defp avg(list) do
+    Enum.sum(list) / length(list)
+  end
+end

--- a/lib/td_core/search/reindex_benchmark.ex
+++ b/lib/td_core/search/reindex_benchmark.ex
@@ -211,7 +211,11 @@ defmodule TdCore.Search.ReindexBenchmark do
   defp gc_stats_pair({count, words}), do: {count, words}
   defp gc_stats_pair({count, words, _}), do: {count, words}
 
-  defp log_run_metrics(%{micros: micros, doc_count: doc_count} = metrics, profile_interval_ms, info) do
+  defp log_run_metrics(
+         %{micros: micros, doc_count: doc_count} = metrics,
+         profile_interval_ms,
+         info
+       ) do
     throughput = throughput_per_sec(doc_count, micros)
 
     info.("""

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule TdCore.MixProject do
   def application do
     [
       mod: {TdCore.Application, []},
-      extra_applications: [:logger]
+      extra_applications: [:logger, :runtime_tools]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TdCore.MixProject do
   def project do
     [
       app: :td_core,
-      version: "8.8.3",
+      version: "8.9.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/bulk_uploader_upload_doc.ex
+++ b/test/support/bulk_uploader_upload_doc.ex
@@ -17,4 +17,34 @@ defmodule TdCore.Search.BulkUploaderUploadStore do
   def stream(_source) do
     Stream.map(1..2, fn id -> %BulkUploaderUploadDoc{id: id} end)
   end
+
+  def transaction(fun), do: fun.()
+end
+
+defmodule TdCore.Search.BulkUploaderTxnRequiredStore do
+  @moduledoc false
+
+  alias TdCore.Search.BulkUploaderUploadDoc
+
+  @txn_key :bulk_uploader_txn_required
+
+  def stream(_source) do
+    Stream.map(1..2, fn id ->
+      unless Process.get(@txn_key) do
+        raise "cannot reduce stream outside of transaction"
+      end
+
+      %BulkUploaderUploadDoc{id: id}
+    end)
+  end
+
+  def transaction(fun) do
+    Process.put(@txn_key, true)
+
+    try do
+      fun.()
+    after
+      Process.delete(@txn_key)
+    end
+  end
 end

--- a/test/support/bulk_uploader_upload_doc.ex
+++ b/test/support/bulk_uploader_upload_doc.ex
@@ -38,6 +38,16 @@ defmodule TdCore.Search.BulkUploaderTxnRequiredStore do
     end)
   end
 
+  def stream(_source, ids) when is_list(ids) do
+    Stream.map(ids, fn id ->
+      unless Process.get(@txn_key) do
+        raise "cannot reduce stream outside of transaction"
+      end
+
+      %BulkUploaderUploadDoc{id: id}
+    end)
+  end
+
   def transaction(fun) do
     Process.put(@txn_key, true)
 

--- a/test/support/bulk_uploader_upload_doc.ex
+++ b/test/support/bulk_uploader_upload_doc.ex
@@ -1,0 +1,20 @@
+defmodule TdCore.Search.BulkUploaderUploadDoc do
+  @moduledoc false
+  defstruct [:id]
+end
+
+defimpl Elasticsearch.Document, for: TdCore.Search.BulkUploaderUploadDoc do
+  def id(%TdCore.Search.BulkUploaderUploadDoc{id: id}), do: id
+  def routing(_), do: false
+  def encode(%TdCore.Search.BulkUploaderUploadDoc{id: id}), do: %{id: id}
+end
+
+defmodule TdCore.Search.BulkUploaderUploadStore do
+  @moduledoc false
+
+  alias TdCore.Search.BulkUploaderUploadDoc
+
+  def stream(_source) do
+    Stream.map(1..2, fn id -> %BulkUploaderUploadDoc{id: id} end)
+  end
+end

--- a/test/td_core/search/bulk_uploader_test.exs
+++ b/test/td_core/search/bulk_uploader_test.exs
@@ -125,7 +125,23 @@ defmodule TdCore.Search.BulkUploaderTest do
   end
 
   describe "record_bulk_response/4" do
-    test "logs took on successful bulk response" do
+    setup do
+      previous = System.get_env("ES_BULK_TOOK_LOG")
+
+      on_exit(fn ->
+        if previous do
+          System.put_env("ES_BULK_TOOK_LOG", previous)
+        else
+          System.delete_env("ES_BULK_TOOK_LOG")
+        end
+      end)
+
+      :ok
+    end
+
+    test "logs took on successful bulk response when ES_BULK_TOOK_LOG is enabled" do
+      System.put_env("ES_BULK_TOOK_LOG", "1")
+
       response = {:ok, %{"errors" => false, "items" => [%{"index" => %{}}, %{"index" => %{}}], "took" => 123}}
 
       log =
@@ -134,6 +150,19 @@ defmodule TdCore.Search.BulkUploaderTest do
         end)
 
       assert log =~ "structures-1: bulk indexed 2 documents (took=123)"
+    end
+
+    test "does not log took when ES_BULK_TOOK_LOG is unset" do
+      System.delete_env("ES_BULK_TOOK_LOG")
+
+      response = {:ok, %{"errors" => false, "items" => [%{"index" => %{}}, %{"index" => %{}}], "took" => 123}}
+
+      log =
+        capture_log(fn ->
+          assert [] == BulkUploader.record_bulk_response("structures-1", response, [], "index")
+        end)
+
+      refute log =~ "took="
     end
 
     test "does not log bulk wait interval ok" do
@@ -187,19 +216,21 @@ defmodule TdCore.Search.BulkUploaderTest do
         {:ok, %{"errors" => false, "items" => [], "took" => 1}}
       end)
 
-      assert :ok ==
-               BulkUploader.upload(
-                 @upload_config,
-                 "upload-idx",
-                 %{
-                   store: BulkUploaderUploadStore,
-                   sources: [BulkUploaderUploadDoc],
-                   bulk_page_size: 1,
-                   bulk_wait_interval: 0,
-                   bulk_action: "index"
-                 },
-                 []
-               )
+      capture_log(fn ->
+        assert :ok ==
+                 BulkUploader.upload(
+                   @upload_config,
+                   "upload-idx",
+                   %{
+                     store: BulkUploaderUploadStore,
+                     sources: [BulkUploaderUploadDoc],
+                     bulk_page_size: 1,
+                     bulk_wait_interval: 0,
+                     bulk_action: "index"
+                   },
+                   []
+                 )
+      end)
 
       assert Agent.get(agent, & &1.max) == 1
     end
@@ -225,21 +256,64 @@ defmodule TdCore.Search.BulkUploaderTest do
         {:ok, %{"errors" => false, "items" => [], "took" => 1}}
       end)
 
-      assert :ok ==
-               BulkUploader.upload(
-                 @upload_config,
-                 "upload-idx",
-                 %{
-                   store: BulkUploaderUploadStore,
-                   sources: [BulkUploaderUploadDoc],
-                   bulk_page_size: 1,
-                   bulk_wait_interval: 0,
-                   bulk_action: "index"
-                 },
-                 []
-               )
+      capture_log(fn ->
+        assert :ok ==
+                 BulkUploader.upload(
+                   @upload_config,
+                   "upload-idx",
+                   %{
+                     store: BulkUploaderUploadStore,
+                     sources: [BulkUploaderUploadDoc],
+                     bulk_page_size: 1,
+                     bulk_wait_interval: 0,
+                     bulk_action: "index"
+                   },
+                   []
+                 )
+      end)
 
       assert Agent.get(agent, & &1.max) >= 2
+    end
+
+    test "consumes store.stream inside store.transaction", %{previous: previous} do
+      Application.put_env(
+        :td_core,
+        TdCore.Search.Cluster,
+        Keyword.put(previous, :reindex_concurrency, 1)
+      )
+
+      alias TdCore.Search.BulkUploaderTxnRequiredStore
+
+      ElasticsearchMock
+      |> expect(:request, 2, fn _, :put, "/upload-idx/_bulk", _body, [] ->
+        {:ok, %{"errors" => false, "items" => [], "took" => 1}}
+      end)
+
+      capture_log(fn ->
+        assert :ok ==
+                 BulkUploader.upload(
+                   @upload_config,
+                   "upload-idx",
+                   %{
+                     store: BulkUploaderTxnRequiredStore,
+                     sources: [BulkUploaderUploadDoc],
+                     bulk_page_size: 1,
+                     bulk_wait_interval: 0,
+                     bulk_action: "index"
+                   },
+                   []
+                 )
+      end)
+    end
+
+    test "raises when stream is reduced outside transaction" do
+      alias TdCore.Search.BulkUploaderTxnRequiredStore
+
+      assert_raise RuntimeError, "cannot reduce stream outside of transaction", fn ->
+        BulkUploaderTxnRequiredStore
+        |> then(fn store -> store.stream(BulkUploaderUploadDoc) end)
+        |> Enum.to_list()
+      end
     end
   end
 end

--- a/test/td_core/search/bulk_uploader_test.exs
+++ b/test/td_core/search/bulk_uploader_test.exs
@@ -145,4 +145,101 @@ defmodule TdCore.Search.BulkUploaderTest do
       assert log == ""
     end
   end
+
+  describe "upload/4" do
+    alias TdCore.Search.BulkUploaderUploadDoc
+    alias TdCore.Search.BulkUploaderUploadStore
+
+    @upload_config %{
+      api: ElasticsearchMock,
+      url: "http://none",
+      json_library: Jason
+    }
+
+    setup do
+      previous = Application.get_env(:td_core, TdCore.Search.Cluster, [])
+
+      on_exit(fn ->
+        Application.put_env(:td_core, TdCore.Search.Cluster, previous)
+      end)
+
+      {:ok, previous: previous}
+    end
+
+    test "runs PUT _bulk serially when reindex_concurrency is 1", %{previous: previous} do
+      Application.put_env(
+        :td_core,
+        TdCore.Search.Cluster,
+        Keyword.put(previous, :reindex_concurrency, 1)
+      )
+
+      {:ok, agent} = Agent.start_link(fn -> %{inflight: 0, max: 0} end)
+
+      ElasticsearchMock
+      |> expect(:request, 2, fn _, :put, "/upload-idx/_bulk", _body, [] ->
+        Agent.update(agent, fn %{inflight: n, max: m} ->
+          %{inflight: n + 1, max: max(m, n + 1)}
+        end)
+
+        Process.sleep(30)
+
+        Agent.update(agent, fn state -> %{state | inflight: state.inflight - 1} end)
+        {:ok, %{"errors" => false, "items" => [], "took" => 1}}
+      end)
+
+      assert :ok ==
+               BulkUploader.upload(
+                 @upload_config,
+                 "upload-idx",
+                 %{
+                   store: BulkUploaderUploadStore,
+                   sources: [BulkUploaderUploadDoc],
+                   bulk_page_size: 1,
+                   bulk_wait_interval: 0,
+                   bulk_action: "index"
+                 },
+                 []
+               )
+
+      assert Agent.get(agent, & &1.max) == 1
+    end
+
+    test "overlaps concurrent PUT _bulk when reindex_concurrency > 1", %{previous: previous} do
+      Application.put_env(
+        :td_core,
+        TdCore.Search.Cluster,
+        Keyword.put(previous, :reindex_concurrency, 2)
+      )
+
+      {:ok, agent} = Agent.start_link(fn -> %{inflight: 0, max: 0} end)
+
+      ElasticsearchMock
+      |> expect(:request, 2, fn _, :put, "/upload-idx/_bulk", _body, [] ->
+        Agent.update(agent, fn %{inflight: n, max: m} ->
+          %{inflight: n + 1, max: max(m, n + 1)}
+        end)
+
+        Process.sleep(50)
+
+        Agent.update(agent, fn state -> %{state | inflight: state.inflight - 1} end)
+        {:ok, %{"errors" => false, "items" => [], "took" => 1}}
+      end)
+
+      assert :ok ==
+               BulkUploader.upload(
+                 @upload_config,
+                 "upload-idx",
+                 %{
+                   store: BulkUploaderUploadStore,
+                   sources: [BulkUploaderUploadDoc],
+                   bulk_page_size: 1,
+                   bulk_wait_interval: 0,
+                   bulk_action: "index"
+                 },
+                 []
+               )
+
+      assert Agent.get(agent, & &1.max) >= 2
+    end
+  end
 end

--- a/test/td_core/search/bulk_uploader_test.exs
+++ b/test/td_core/search/bulk_uploader_test.exs
@@ -1,6 +1,7 @@
 defmodule TdCore.Search.BulkUploaderTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
   import Mox
 
   alias TdCore.Search.BulkUploader
@@ -120,6 +121,28 @@ defmodule TdCore.Search.BulkUploaderTest do
       assert length(results) == 2
       assert Enum.any?(results, &match?({:ok, %{"errors" => true}}, &1))
       assert Enum.any?(results, &match?({:ok, %{"errors" => false}}, &1))
+    end
+  end
+
+  describe "record_bulk_response/4" do
+    test "logs took on successful bulk response" do
+      response = {:ok, %{"errors" => false, "items" => [%{"index" => %{}}, %{"index" => %{}}], "took" => 123}}
+
+      log =
+        capture_log(fn ->
+          assert [] == BulkUploader.record_bulk_response("structures-1", response, [], "index")
+        end)
+
+      assert log =~ "structures-1: bulk indexed 2 documents (took=123)"
+    end
+
+    test "does not log bulk wait interval ok" do
+      log =
+        capture_log(fn ->
+          assert [] == BulkUploader.record_bulk_response("structures-1", :ok, [], "index")
+        end)
+
+      assert log == ""
     end
   end
 end

--- a/test/td_core/search/bulk_uploader_test.exs
+++ b/test/td_core/search/bulk_uploader_test.exs
@@ -1,0 +1,125 @@
+defmodule TdCore.Search.BulkUploaderTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias TdCore.Search.BulkUploader
+  alias TdCore.Search.Cluster
+
+  setup :verify_on_exit!
+
+  defmodule Collector do
+    @moduledoc false
+    @agent __MODULE__
+
+    def start do
+      case Agent.start_link(fn -> [] end, name: @agent) do
+        {:ok, pid} ->
+          pid
+
+        {:error, {:already_started, pid}} ->
+          Agent.update(@agent, fn _ -> [] end)
+          pid
+      end
+    end
+
+    def time(phase, fun) do
+      Agent.update(@agent, &[phase | &1])
+      fun.()
+    end
+
+    def phases, do: Agent.get(@agent, &Enum.reverse/1)
+  end
+
+  setup do
+    on_exit(fn -> Application.delete_env(:td_core, :search_phase_profiler) end)
+    :ok
+  end
+
+  describe "post_bulk_bodies/4 with concurrency <= 1" do
+    test "posts every body preserving order and returns responses" do
+      ElasticsearchMock
+      |> expect(:request, 2, fn _, :post, "/idx/_bulk", body, [] ->
+        {:ok, %{"echo" => body}}
+      end)
+
+      results =
+        ["first", "second"]
+        |> BulkUploader.post_bulk_bodies(Cluster, "/idx/_bulk", 1)
+        |> Enum.to_list()
+
+      assert results == [{:ok, %{"echo" => "first"}}, {:ok, %{"echo" => "second"}}]
+    end
+
+    test "invokes the :bulk_es phase hook once per body when profiler is configured" do
+      Collector.start()
+      Application.put_env(:td_core, :search_phase_profiler, {Collector, :time})
+
+      ElasticsearchMock
+      |> expect(:request, 2, fn _, :post, "/idx/_bulk", body, [] ->
+        {:ok, %{"echo" => body}}
+      end)
+
+      ["a", "b"]
+      |> BulkUploader.post_bulk_bodies(Cluster, "/idx/_bulk", 1)
+      |> Stream.run()
+
+      assert Collector.phases() == [:bulk_es, :bulk_es]
+    end
+
+    test "runs without hooks when profiler is not configured" do
+      Application.delete_env(:td_core, :search_phase_profiler)
+
+      ElasticsearchMock
+      |> expect(:request, 1, fn _, :post, "/idx/_bulk", "body", [] ->
+        {:ok, %{"errors" => false}}
+      end)
+
+      results =
+        ["body"]
+        |> BulkUploader.post_bulk_bodies(Cluster, "/idx/_bulk", 1)
+        |> Enum.to_list()
+
+      assert results == [{:ok, %{"errors" => false}}]
+    end
+  end
+
+  describe "post_bulk_bodies/4 with concurrency > 1" do
+    test "posts all bodies preserving stream order when concurrency > 1" do
+      ElasticsearchMock
+      |> expect(:request, 3, fn _, :post, "/idx/_bulk", body, [] ->
+        {:ok, %{"echo" => body}}
+      end)
+
+      results =
+        ["a", "b", "c"]
+        |> BulkUploader.post_bulk_bodies(Cluster, "/idx/_bulk", 2)
+        |> Enum.to_list()
+
+      assert results == [
+               {:ok, %{"echo" => "a"}},
+               {:ok, %{"echo" => "b"}},
+               {:ok, %{"echo" => "c"}}
+             ]
+    end
+
+    test "collects errors from all responses regardless of completion order" do
+      ElasticsearchMock
+      |> expect(:request, 2, fn _, :post, "/idx/_bulk", body, [] ->
+        case body do
+          "ok" -> {:ok, %{"errors" => false, "items" => []}}
+          "fail" -> {:ok, %{"errors" => true, "items" => [%{"index" => %{"error" => %{"type" => "x"}}}]}}
+        end
+      end)
+
+      results =
+        ["ok", "fail"]
+        |> BulkUploader.post_bulk_bodies(Cluster, "/idx/_bulk", 2)
+        |> Enum.to_list()
+
+      assert length(results) == 2
+      assert Enum.any?(results, &match?({:ok, %{"errors" => true}}, &1))
+      assert Enum.any?(results, &match?({:ok, %{"errors" => false}}, &1))
+    end
+  end
+end

--- a/test/td_core/search/bulk_uploader_test.exs
+++ b/test/td_core/search/bulk_uploader_test.exs
@@ -108,8 +108,11 @@ defmodule TdCore.Search.BulkUploaderTest do
       ElasticsearchMock
       |> expect(:request, 2, fn _, :post, "/idx/_bulk", body, [] ->
         case body do
-          "ok" -> {:ok, %{"errors" => false, "items" => []}}
-          "fail" -> {:ok, %{"errors" => true, "items" => [%{"index" => %{"error" => %{"type" => "x"}}}]}}
+          "ok" ->
+            {:ok, %{"errors" => false, "items" => []}}
+
+          "fail" ->
+            {:ok, %{"errors" => true, "items" => [%{"index" => %{"error" => %{"type" => "x"}}}]}}
         end
       end)
 

--- a/test/td_core/search/bulk_uploader_test.exs
+++ b/test/td_core/search/bulk_uploader_test.exs
@@ -125,44 +125,39 @@ defmodule TdCore.Search.BulkUploaderTest do
   end
 
   describe "record_bulk_response/4" do
-    setup do
-      previous = System.get_env("ES_BULK_TOOK_LOG")
-
-      on_exit(fn ->
-        if previous do
-          System.put_env("ES_BULK_TOOK_LOG", previous)
-        else
-          System.delete_env("ES_BULK_TOOK_LOG")
-        end
-      end)
-
-      :ok
-    end
-
-    test "logs took on successful bulk response when ES_BULK_TOOK_LOG is enabled" do
-      System.put_env("ES_BULK_TOOK_LOG", "1")
-
-      response = {:ok, %{"errors" => false, "items" => [%{"index" => %{}}, %{"index" => %{}}], "took" => 123}}
+    test "logs took on successful bulk response and collects no errors" do
+      response =
+        {:ok,
+         %{"errors" => false, "items" => [%{"index" => %{}}, %{"index" => %{}}], "took" => 123}}
 
       log =
-        capture_log(fn ->
+        capture_log([level: :debug], fn ->
           assert [] == BulkUploader.record_bulk_response("structures-1", response, [], "index")
         end)
 
       assert log =~ "structures-1: bulk indexed 2 documents (took=123)"
     end
 
-    test "does not log took when ES_BULK_TOOK_LOG is unset" do
-      System.delete_env("ES_BULK_TOOK_LOG")
+    test "collects errors from a failed bulk response" do
+      response =
+        {:ok,
+         %{
+           "errors" => true,
+           "items" => [
+             %{
+               "index" => %{
+                 "_id" => "7",
+                 "status" => 400,
+                 "error" => %{"reason" => "boom", "type" => "mapper_parsing_exception"}
+               }
+             }
+           ]
+         }}
 
-      response = {:ok, %{"errors" => false, "items" => [%{"index" => %{}}, %{"index" => %{}}], "took" => 123}}
-
-      log =
-        capture_log(fn ->
-          assert [] == BulkUploader.record_bulk_response("structures-1", response, [], "index")
-        end)
-
-      refute log =~ "took="
+      capture_log(fn ->
+        assert [%Elasticsearch.Exception{}] =
+                 BulkUploader.record_bulk_response("structures-1", response, [], "index")
+      end)
     end
 
     test "does not log bulk wait interval ok" do

--- a/test/td_core/search/bulk_uploader_test.exs
+++ b/test/td_core/search/bulk_uploader_test.exs
@@ -7,6 +7,12 @@ defmodule TdCore.Search.BulkUploaderTest do
   alias TdCore.Search.BulkUploader
   alias TdCore.Search.Cluster
 
+  @upload_config %{
+    api: ElasticsearchMock,
+    url: "http://none",
+    json_library: Jason
+  }
+
   setup :verify_on_exit!
 
   defmodule Collector do
@@ -174,43 +180,21 @@ defmodule TdCore.Search.BulkUploaderTest do
   end
 
   describe "upload/4" do
+    alias TdCore.Search.BulkUploaderTxnRequiredStore
     alias TdCore.Search.BulkUploaderUploadDoc
     alias TdCore.Search.BulkUploaderUploadStore
 
-    @upload_config %{
-      api: ElasticsearchMock,
-      url: "http://none",
-      json_library: Jason
-    }
-
-    setup do
-      previous = Application.get_env(:td_core, TdCore.Search.Cluster, [])
-
-      on_exit(fn ->
-        Application.put_env(:td_core, TdCore.Search.Cluster, previous)
-      end)
-
-      {:ok, previous: previous}
-    end
-
-    test "runs PUT _bulk serially when reindex_concurrency is 1", %{previous: previous} do
-      Application.put_env(
-        :td_core,
-        TdCore.Search.Cluster,
-        Keyword.put(previous, :reindex_concurrency, 1)
-      )
-
-      {:ok, agent} = Agent.start_link(fn -> %{inflight: 0, max: 0} end)
-
+    test "uploads every document from the store, one page per bulk_page_size" do
       ElasticsearchMock
-      |> expect(:request, 2, fn _, :put, "/upload-idx/_bulk", _body, [] ->
-        Agent.update(agent, fn %{inflight: n, max: m} ->
-          %{inflight: n + 1, max: max(m, n + 1)}
-        end)
-
-        Process.sleep(30)
-
-        Agent.update(agent, fn state -> %{state | inflight: state.inflight - 1} end)
+      |> expect(:request, fn _, :put, "/upload-idx/_bulk", body, [] ->
+        assert body =~ ~s("index":)
+        assert body =~ ~s("_id":1)
+        assert body =~ ~s("id":1)
+        {:ok, %{"errors" => false, "items" => [], "took" => 1}}
+      end)
+      |> expect(:request, fn _, :put, "/upload-idx/_bulk", body, [] ->
+        assert body =~ ~s("_id":2)
+        assert body =~ ~s("id":2)
         {:ok, %{"errors" => false, "items" => [], "took" => 1}}
       end)
 
@@ -219,38 +203,18 @@ defmodule TdCore.Search.BulkUploaderTest do
                  BulkUploader.upload(
                    @upload_config,
                    "upload-idx",
-                   %{
-                     store: BulkUploaderUploadStore,
-                     sources: [BulkUploaderUploadDoc],
-                     bulk_page_size: 1,
-                     bulk_wait_interval: 0,
-                     bulk_action: "index"
-                   },
+                   index_config(BulkUploaderUploadStore, 1),
                    []
                  )
       end)
-
-      assert Agent.get(agent, & &1.max) == 1
     end
 
-    test "overlaps concurrent PUT _bulk when reindex_concurrency > 1", %{previous: previous} do
-      Application.put_env(
-        :td_core,
-        TdCore.Search.Cluster,
-        Keyword.put(previous, :reindex_concurrency, 2)
-      )
-
-      {:ok, agent} = Agent.start_link(fn -> %{inflight: 0, max: 0} end)
-
+    test "uploads the same documents when concurrency is greater than 1" do
       ElasticsearchMock
-      |> expect(:request, 2, fn _, :put, "/upload-idx/_bulk", _body, [] ->
-        Agent.update(agent, fn %{inflight: n, max: m} ->
-          %{inflight: n + 1, max: max(m, n + 1)}
-        end)
-
-        Process.sleep(50)
-
-        Agent.update(agent, fn state -> %{state | inflight: state.inflight - 1} end)
+      |> expect(:request, 2, fn _, :put, "/upload-idx/_bulk", body, [] ->
+        assert body =~ ~s("index":)
+        assert body =~ ~r/"_id":[12]/
+        assert body =~ ~r/"id":[12]/
         {:ok, %{"errors" => false, "items" => [], "took" => 1}}
       end)
 
@@ -259,29 +223,45 @@ defmodule TdCore.Search.BulkUploaderTest do
                  BulkUploader.upload(
                    @upload_config,
                    "upload-idx",
-                   %{
-                     store: BulkUploaderUploadStore,
-                     sources: [BulkUploaderUploadDoc],
-                     bulk_page_size: 1,
-                     bulk_wait_interval: 0,
-                     bulk_action: "index"
-                   },
+                   index_config(BulkUploaderUploadStore, 4),
                    []
                  )
       end)
-
-      assert Agent.get(agent, & &1.max) >= 2
     end
 
-    test "consumes store.stream inside store.transaction", %{previous: previous} do
-      Application.put_env(
-        :td_core,
-        TdCore.Search.Cluster,
-        Keyword.put(previous, :reindex_concurrency, 1)
-      )
+    test "returns collected errors when a bulk page fails" do
+      ElasticsearchMock
+      |> expect(:request, 2, fn _, :put, "/upload-idx/_bulk", _body, [] ->
+        {:ok,
+         %{
+           "errors" => true,
+           "items" => [
+             %{
+               "index" => %{
+                 "_id" => "1",
+                 "status" => 400,
+                 "error" => %{"reason" => "boom", "type" => "mapper_parsing_exception"}
+               }
+             }
+           ]
+         }}
+      end)
 
-      alias TdCore.Search.BulkUploaderTxnRequiredStore
+      capture_log(fn ->
+        assert {:error, errors} =
+                 BulkUploader.upload(
+                   @upload_config,
+                   "upload-idx",
+                   index_config(BulkUploaderUploadStore, 1),
+                   []
+                 )
 
+        assert length(errors) == 2
+        assert Enum.all?(errors, &match?(%Elasticsearch.Exception{}, &1))
+      end)
+    end
+
+    test "consumes store.stream inside store.transaction" do
       ElasticsearchMock
       |> expect(:request, 2, fn _, :put, "/upload-idx/_bulk", _body, [] ->
         {:ok, %{"errors" => false, "items" => [], "took" => 1}}
@@ -292,26 +272,29 @@ defmodule TdCore.Search.BulkUploaderTest do
                  BulkUploader.upload(
                    @upload_config,
                    "upload-idx",
-                   %{
-                     store: BulkUploaderTxnRequiredStore,
-                     sources: [BulkUploaderUploadDoc],
-                     bulk_page_size: 1,
-                     bulk_wait_interval: 0,
-                     bulk_action: "index"
-                   },
+                   index_config(BulkUploaderTxnRequiredStore, 1),
                    []
                  )
       end)
     end
 
     test "raises when stream is reduced outside transaction" do
-      alias TdCore.Search.BulkUploaderTxnRequiredStore
-
       assert_raise RuntimeError, "cannot reduce stream outside of transaction", fn ->
         BulkUploaderTxnRequiredStore
         |> then(fn store -> store.stream(BulkUploaderUploadDoc) end)
         |> Enum.to_list()
       end
     end
+  end
+
+  defp index_config(store, concurrency) do
+    %{
+      store: store,
+      sources: [TdCore.Search.BulkUploaderUploadDoc],
+      bulk_page_size: 1,
+      bulk_wait_interval: 0,
+      bulk_action: "index",
+      reindex_concurrency: concurrency
+    }
   end
 end

--- a/test/td_core/search/indexer_test.exs
+++ b/test/td_core/search/indexer_test.exs
@@ -494,4 +494,57 @@ defmodule TdCore.Search.IndexerTest do
                })
     end
   end
+
+  describe "finalize_hot_swap_index/2" do
+    test "refreshes without forcemerge using dedicated recv_timeout" do
+      ElasticsearchMock
+      |> expect(:request, fn _, :post, "/structures-1/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+        {:ok, %{"_shards" => %{"successful" => 1}}}
+      end)
+
+      assert :ok = Indexer.finalize_hot_swap_index(Cluster, "structures-1")
+    end
+
+    test "returns error when refresh times out" do
+      error = %HTTPoison.Error{reason: :timeout, id: nil}
+
+      ElasticsearchMock
+      |> expect(:request, fn _, :post, "/structures-1/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+        {:error, error}
+      end)
+
+      assert {:error, ^error} = Indexer.finalize_hot_swap_index(Cluster, "structures-1")
+    end
+  end
+
+  describe "refresh skip_forcemerge" do
+    test "skips forcemerge when skip_forcemerge is true" do
+      ElasticsearchMock
+      |> expect(:request, fn _, :post, "/concepts/_refresh", _, [] ->
+        {:ok, :success}
+      end)
+
+      assert :ok == Indexer.refresh(Cluster, "concepts", skip_forcemerge: true)
+    end
+
+    test "passes recv_timeout to refresh and forcemerge requests" do
+      ElasticsearchMock
+      |> expect(:request, fn _, :post, "/concepts/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+        {:ok, :success}
+      end)
+      |> expect(:request, fn _,
+                             :post,
+                             "/concepts/_forcemerge?max_num_segments=5",
+                             _,
+                             opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+        {:ok, :success}
+      end)
+
+      assert :ok == Indexer.refresh(Cluster, "concepts", recv_timeout: 5_000)
+    end
+  end
 end

--- a/test/td_core/search/indexer_test.exs
+++ b/test/td_core/search/indexer_test.exs
@@ -615,4 +615,55 @@ defmodule TdCore.Search.IndexerTest do
       refute log =~ "took="
     end
   end
+
+  describe "reindex/2 with ids" do
+    setup do
+      alias Elasticsearch.Cluster.Config
+      alias TdCore.Search.BulkUploaderTxnRequiredStore
+
+      previous_config = Config.get(Cluster)
+      previous_env = Application.get_env(:td_core, TdCore.Search.Cluster, [])
+
+      Application.put_env(
+        :td_core,
+        TdCore.Search.Cluster,
+        Keyword.put(previous_env, :reindex_concurrency, 1)
+      )
+
+      updated =
+        previous_config
+        |> Map.put_new(:json_library, Jason)
+        |> Map.put(:indexes, %{
+          string_test_alias: %{
+            store: BulkUploaderTxnRequiredStore,
+            sources: [TdCore.Search.BulkUploaderUploadDoc],
+            bulk_page_size: 1,
+            bulk_wait_interval: 0,
+            settings: %{}
+          }
+        })
+
+      :sys.replace_state(Cluster, fn _ -> updated end)
+      GenServer.call(Cluster, :save_config)
+
+      on_exit(fn ->
+        :sys.replace_state(Cluster, fn _ -> previous_config end)
+        GenServer.call(Cluster, :save_config)
+        Application.put_env(:td_core, TdCore.Search.Cluster, previous_env)
+      end)
+
+      :ok
+    end
+
+    test "consumes store.stream(ids) inside store.transaction" do
+      ElasticsearchMock
+      |> expect(:request, fn _, :post, "/string_test_alias/_bulk", _body, [] ->
+        {:ok, %{"errors" => false, "items" => [], "took" => 1}}
+      end)
+
+      capture_log(fn ->
+        assert :ok == Indexer.reindex(:test_alias, [12619])
+      end)
+    end
+  end
 end

--- a/test/td_core/search/indexer_test.exs
+++ b/test/td_core/search/indexer_test.exs
@@ -547,4 +547,72 @@ defmodule TdCore.Search.IndexerTest do
       assert :ok == Indexer.refresh(Cluster, "concepts", recv_timeout: 5_000)
     end
   end
+
+  describe "log_bulk_post took= env gate" do
+    setup do
+      previous = System.get_env("ES_BULK_TOOK_LOG")
+
+      on_exit(fn ->
+        if previous do
+          System.put_env("ES_BULK_TOOK_LOG", previous)
+        else
+          System.delete_env("ES_BULK_TOOK_LOG")
+        end
+      end)
+
+      response =
+        {:ok,
+         %{
+           "errors" => false,
+           "items" => [%{"index" => %{}}, %{"index" => %{}}],
+           "took" => 42
+         }}
+
+      [response: response]
+    end
+
+    test "logs took when ES_BULK_TOOK_LOG is 1", %{response: response} do
+      System.put_env("ES_BULK_TOOK_LOG", "1")
+
+      log =
+        capture_log(fn ->
+          Indexer.log_bulk_post("structures", response, "index")
+        end)
+
+      assert log =~ "structures: bulk indexed 2 documents (took=42)"
+    end
+
+    test "logs took when ES_BULK_TOOK_LOG is true", %{response: response} do
+      System.put_env("ES_BULK_TOOK_LOG", "TRUE")
+
+      log =
+        capture_log(fn ->
+          Indexer.log_bulk_post("structures", response, "index")
+        end)
+
+      assert log =~ "took=42"
+    end
+
+    test "does not log took when ES_BULK_TOOK_LOG is unset", %{response: response} do
+      System.delete_env("ES_BULK_TOOK_LOG")
+
+      log =
+        capture_log(fn ->
+          Indexer.log_bulk_post("structures", response, "index")
+        end)
+
+      refute log =~ "took="
+    end
+
+    test "does not log took when ES_BULK_TOOK_LOG is 0", %{response: response} do
+      System.put_env("ES_BULK_TOOK_LOG", "0")
+
+      log =
+        capture_log(fn ->
+          Indexer.log_bulk_post("structures", response, "index")
+        end)
+
+      refute log =~ "took="
+    end
+  end
 end

--- a/test/td_core/search/indexer_test.exs
+++ b/test/td_core/search/indexer_test.exs
@@ -421,4 +421,77 @@ defmodule TdCore.Search.IndexerTest do
       assert :ok = Indexer.ensure_index_exists(:test_alias)
     end
   end
+
+  describe "bulk_load_index_settings/1" do
+    test "overrides refresh_interval and number_of_replicas for bulk load" do
+      settings = %{
+        "refresh_interval" => "5s",
+        "number_of_replicas" => 1,
+        analysis: %{tokenizer: %{}}
+      }
+
+      assert %{
+               "refresh_interval" => "-1",
+               "number_of_replicas" => 0,
+               analysis: %{tokenizer: %{}}
+             } = Indexer.bulk_load_index_settings(settings)
+    end
+  end
+
+  describe "production_index_settings/1" do
+    test "builds restore body from string keys" do
+      settings = %{"refresh_interval" => "10s", "number_of_replicas" => 2}
+
+      assert %{
+               "index" => %{
+                 "refresh_interval" => "10s",
+                 "number_of_replicas" => 2
+               }
+             } = Indexer.production_index_settings(settings)
+    end
+
+    test "falls back to defaults when keys are missing" do
+      assert %{
+               "index" => %{
+                 "refresh_interval" => "5s",
+                 "number_of_replicas" => 1
+               }
+             } = Indexer.production_index_settings(%{})
+    end
+  end
+
+  describe "restore_index_settings/3" do
+    test "puts production settings to the index" do
+      settings = %{"refresh_interval" => "10s", "number_of_replicas" => 2}
+
+      ElasticsearchMock
+      |> expect(:request, fn _, :put, "/structures-1/_settings", body, [] ->
+        assert body == %{
+                 "index" => %{
+                   "refresh_interval" => "10s",
+                   "number_of_replicas" => 2
+                 }
+               }
+
+        {:ok, %{"acknowledged" => true}}
+      end)
+
+      assert :ok = Indexer.restore_index_settings(Cluster, "structures-1", settings)
+    end
+
+    test "returns error when Elasticsearch rejects the update" do
+      error = %HTTPoison.Error{reason: :timeout, id: nil}
+
+      ElasticsearchMock
+      |> expect(:request, fn _, :put, "/structures-1/_settings", _, [] ->
+        {:error, error}
+      end)
+
+      assert {:error, ^error} =
+               Indexer.restore_index_settings(Cluster, "structures-1", %{
+                 "refresh_interval" => "5s",
+                 "number_of_replicas" => 1
+               })
+    end
+  end
 end

--- a/test/td_core/search/indexer_test.exs
+++ b/test/td_core/search/indexer_test.exs
@@ -351,7 +351,9 @@ defmodule TdCore.Search.IndexerTest do
 
   describe "refresh" do
     test "refreshes index with default params" do
-      Mox.expect(ElasticsearchMock, :request, 1, fn _, :post, "/concepts/_refresh", _, [] ->
+      Mox.expect(ElasticsearchMock, :request, 1, fn _, :post, "/concepts/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+
         {:ok, :success}
       end)
 
@@ -367,7 +369,9 @@ defmodule TdCore.Search.IndexerTest do
     end
 
     test "refreshes index with opt params" do
-      Mox.expect(ElasticsearchMock, :request, 1, fn _, :post, "/concepts/_refresh", _, [] ->
+      Mox.expect(ElasticsearchMock, :request, 1, fn _, :post, "/concepts/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+
         {:ok, :success}
       end)
 
@@ -389,7 +393,9 @@ defmodule TdCore.Search.IndexerTest do
     end
 
     test "rejects nil opt param" do
-      Mox.expect(ElasticsearchMock, :request, 1, fn _, :post, "/concepts/_refresh", _, [] ->
+      Mox.expect(ElasticsearchMock, :request, 1, fn _, :post, "/concepts/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+
         {:ok, :success}
       end)
 
@@ -495,56 +501,82 @@ defmodule TdCore.Search.IndexerTest do
     end
   end
 
-  describe "finalize_hot_swap_index/2" do
-    test "refreshes without forcemerge using dedicated recv_timeout" do
-      ElasticsearchMock
-      |> expect(:request, fn _, :post, "/structures-1/_refresh", _, opts ->
-        assert Keyword.get(opts, :recv_timeout) == 5_000
-        {:ok, %{"_shards" => %{"successful" => 1}}}
-      end)
-
-      assert :ok = Indexer.finalize_hot_swap_index(Cluster, "structures-1")
-    end
-
-    test "returns error when refresh times out" do
-      error = %HTTPoison.Error{reason: :timeout, id: nil}
-
-      ElasticsearchMock
-      |> expect(:request, fn _, :post, "/structures-1/_refresh", _, opts ->
-        assert Keyword.get(opts, :recv_timeout) == 5_000
-        {:error, error}
-      end)
-
-      assert {:error, ^error} = Indexer.finalize_hot_swap_index(Cluster, "structures-1")
-    end
-  end
-
   describe "refresh skip_forcemerge" do
     test "skips forcemerge when skip_forcemerge is true" do
       ElasticsearchMock
-      |> expect(:request, fn _, :post, "/concepts/_refresh", _, [] ->
+      |> expect(:request, fn _, :post, "/concepts/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+
         {:ok, :success}
       end)
 
       assert :ok == Indexer.refresh(Cluster, "concepts", skip_forcemerge: true)
     end
 
-    test "passes recv_timeout to refresh and forcemerge requests" do
+    test "forcemerges with the configured options when skip_forcemerge is false" do
+      ElasticsearchMock
+      |> expect(:request, fn _, :post, "/concepts/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 5_000
+
+        {:ok, :success}
+      end)
+      |> expect(:request, fn _,
+                             :post,
+                             "/concepts/_forcemerge?max_num_segments=10&wait_for_completion=true",
+                             _,
+                             [] ->
+        {:ok, :success}
+      end)
+
+      assert :ok ==
+               Indexer.refresh(Cluster, "concepts",
+                 skip_forcemerge: false,
+                 forcemerge_options: [max_num_segments: 10, wait_for_completion: true]
+               )
+    end
+  end
+
+  describe "refresh recv_timeout" do
+    test "caps the _refresh request without capping _forcemerge" do
       ElasticsearchMock
       |> expect(:request, fn _, :post, "/concepts/_refresh", _, opts ->
         assert Keyword.get(opts, :recv_timeout) == 5_000
         {:ok, :success}
       end)
-      |> expect(:request, fn _,
-                             :post,
-                             "/concepts/_forcemerge?max_num_segments=5",
-                             _,
-                             opts ->
-        assert Keyword.get(opts, :recv_timeout) == 5_000
+      |> expect(:request, fn _, :post, "/concepts/_forcemerge?max_num_segments=5", _, opts ->
+        assert opts == []
         {:ok, :success}
       end)
 
-      assert :ok == Indexer.refresh(Cluster, "concepts", recv_timeout: 5_000)
+      assert :ok == Indexer.refresh(Cluster, "concepts")
+    end
+
+    test "honours a refresh_recv_timeout override" do
+      ElasticsearchMock
+      |> expect(:request, fn _, :post, "/concepts/_refresh", _, opts ->
+        assert Keyword.get(opts, :recv_timeout) == 30_000
+        {:ok, :success}
+      end)
+
+      assert :ok ==
+               Indexer.refresh(Cluster, "concepts",
+                 refresh_recv_timeout: 30_000,
+                 skip_forcemerge: true
+               )
+    end
+
+    test "sends no recv_timeout when refresh_recv_timeout is nil" do
+      ElasticsearchMock
+      |> expect(:request, fn _, :post, "/concepts/_refresh", _, opts ->
+        assert opts == []
+        {:ok, :success}
+      end)
+
+      assert :ok ==
+               Indexer.refresh(Cluster, "concepts",
+                 refresh_recv_timeout: nil,
+                 skip_forcemerge: true
+               )
     end
   end
 

--- a/test/td_core/search/indexer_test.exs
+++ b/test/td_core/search/indexer_test.exs
@@ -580,18 +580,8 @@ defmodule TdCore.Search.IndexerTest do
     end
   end
 
-  describe "log_bulk_post took= env gate" do
-    setup do
-      previous = System.get_env("ES_BULK_TOOK_LOG")
-
-      on_exit(fn ->
-        if previous do
-          System.put_env("ES_BULK_TOOK_LOG", previous)
-        else
-          System.delete_env("ES_BULK_TOOK_LOG")
-        end
-      end)
-
+  describe "log_bulk_post on success" do
+    test "logs the indexed count and took at debug level" do
       response =
         {:ok,
          %{
@@ -600,47 +590,25 @@ defmodule TdCore.Search.IndexerTest do
            "took" => 42
          }}
 
-      [response: response]
-    end
-
-    test "logs took when ES_BULK_TOOK_LOG is 1", %{response: response} do
-      System.put_env("ES_BULK_TOOK_LOG", "1")
-
       log =
-        capture_log(fn ->
-          Indexer.log_bulk_post("structures", response, "index")
+        capture_log([level: :debug], fn ->
+          assert :ok == Indexer.log_bulk_post("structures", response, "index")
         end)
 
       assert log =~ "structures: bulk indexed 2 documents (took=42)"
     end
 
-    test "logs took when ES_BULK_TOOK_LOG is true", %{response: response} do
-      System.put_env("ES_BULK_TOOK_LOG", "TRUE")
+    test "is filtered out when the log level is above debug" do
+      response =
+        {:ok,
+         %{
+           "errors" => false,
+           "items" => [%{"index" => %{}}],
+           "took" => 42
+         }}
 
       log =
-        capture_log(fn ->
-          Indexer.log_bulk_post("structures", response, "index")
-        end)
-
-      assert log =~ "took=42"
-    end
-
-    test "does not log took when ES_BULK_TOOK_LOG is unset", %{response: response} do
-      System.delete_env("ES_BULK_TOOK_LOG")
-
-      log =
-        capture_log(fn ->
-          Indexer.log_bulk_post("structures", response, "index")
-        end)
-
-      refute log =~ "took="
-    end
-
-    test "does not log took when ES_BULK_TOOK_LOG is 0", %{response: response} do
-      System.put_env("ES_BULK_TOOK_LOG", "0")
-
-      log =
-        capture_log(fn ->
+        capture_log([level: :info], fn ->
           Indexer.log_bulk_post("structures", response, "index")
         end)
 

--- a/test/td_core/search/phase_profiler_test.exs
+++ b/test/td_core/search/phase_profiler_test.exs
@@ -1,0 +1,69 @@
+defmodule TdCore.Search.PhaseProfilerTest do
+  use ExUnit.Case, async: false
+
+  import TdCore.Search.PhaseProfiler
+
+  defmodule Collector do
+    @moduledoc false
+    @agent __MODULE__
+
+    def start do
+      case Agent.start_link(fn -> [] end, name: @agent) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> Agent.update(@agent, fn _ -> [] end) && pid
+      end
+    end
+
+    def time(phase, fun) do
+      Agent.update(@agent, &[phase | &1])
+      fun.()
+    end
+
+    def phases, do: Agent.get(@agent, &Enum.reverse/1)
+  end
+
+  setup do
+    on_exit(fn -> Application.delete_env(:td_core, :search_phase_profiler) end)
+    :ok
+  end
+
+  describe "phase_time/2 without profiler configured" do
+    test "runs the function directly and returns its result" do
+      Application.delete_env(:td_core, :search_phase_profiler)
+
+      assert phase_time(:encode, fn -> :encoded end) == :encoded
+    end
+
+    test "ignores unrelated env values" do
+      Application.put_env(:td_core, :search_phase_profiler, :not_a_tuple)
+
+      assert phase_time(:bulk_es, fn -> 7 end) == 7
+    end
+  end
+
+  describe "phase_time/2 with a {module, function} profiler" do
+    setup do
+      Collector.start()
+      Application.put_env(:td_core, :search_phase_profiler, {Collector, :time})
+      :ok
+    end
+
+    test "delegates to the configured callback and returns the function result" do
+      assert phase_time(:encode, fn -> :body end) == :body
+      assert phase_time(:bulk_es, fn -> {:ok, :posted} end) == {:ok, :posted}
+    end
+
+    test "invokes the callback once per phase_time call preserving order" do
+      phase_time(:encode, fn -> :a end)
+      phase_time(:bulk_es, fn -> :b end)
+      phase_time(:encode, fn -> :c end)
+
+      assert Collector.phases() == [:encode, :bulk_es, :encode]
+    end
+
+    test "propagates the phase argument to the callback" do
+      assert phase_time(:custom_phase, fn -> :ok end) == :ok
+      assert :custom_phase in Collector.phases()
+    end
+  end
+end

--- a/test/td_core/search/reindex_benchmark_test.exs
+++ b/test/td_core/search/reindex_benchmark_test.exs
@@ -1,0 +1,90 @@
+defmodule TdCore.Search.ReindexBenchmarkTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias TdCore.Search.ReindexBenchmark
+
+  describe "run/3" do
+    test "prints banner and summary and returns metrics without calling real Indexer" do
+      reindex_fn = fn index, target ->
+        send(self(), {:reindex_called, index, target})
+        :ok
+      end
+
+      output =
+        capture_io(fn ->
+          results =
+            ReindexBenchmark.run(:structures, [1, 2, 3],
+              doc_count: 3,
+              repeat: 1,
+              profile: false,
+              reindex_fn: reindex_fn,
+              env_banner_fn: fn -> [enrich_concurrency: 2] end
+            )
+
+          assert length(results) == 1
+          assert hd(results).result == :ok
+          assert hd(results).doc_count == 3
+          assert hd(results).micros >= 0
+        end)
+
+      assert_received {:reindex_called, :structures, [1, 2, 3]}
+      assert output =~ "Benchmark configuration:"
+      assert output =~ "target               3 ids"
+      assert output =~ "documents            3"
+      assert output =~ "enrich_concurrency   2"
+      assert output =~ "Timing:"
+      assert output =~ "wall_clock"
+      assert output =~ "throughput"
+      assert output =~ "reindex result       :ok"
+    end
+
+    test "supports :all target and repeat > 1 summary" do
+      reindex_fn = fn _index, target ->
+        send(self(), {:target, target})
+        :ok
+      end
+
+      output =
+        capture_io(fn ->
+          results =
+            ReindexBenchmark.run(:implementations, :all,
+              doc_count: 10,
+              repeat: 2,
+              reindex_fn: reindex_fn
+            )
+
+          assert length(results) == 2
+        end)
+
+      assert_received {:target, :all}
+      assert_received {:target, :all}
+      assert output =~ "target               :all"
+      assert output =~ "=== Repeat summary (2 runs) ==="
+    end
+
+    test "profile sampling includes profile section when enabled" do
+      reindex_fn = fn _index, _target ->
+        Process.sleep(60)
+        :ok
+      end
+
+      output =
+        capture_io(fn ->
+          [metrics] =
+            ReindexBenchmark.run(:structures, [1],
+              doc_count: 1,
+              profile: true,
+              profile_interval_ms: 20,
+              reindex_fn: reindex_fn
+            )
+
+          assert length(metrics.samples) >= 1
+        end)
+
+      assert output =~ "Profile samples"
+      assert output =~ "memory total"
+    end
+  end
+end


### PR DESCRIPTION
- Added `TdCore.Search.BulkUploader` for parallel Elasticsearch bulk uploads during hot-swap and partial reindex.
- Modified `TdCore.Search.Indexer` to utilize parallel bulk posts via `ES_REINDEX_CONCURRENCY`.
- Enhanced `TdCore.Search.IndexWorkerImpl` to skip duplicate full reindex casts while one is already in progress.